### PR TITLE
Shutdown action and watchpoint index

### DIFF
--- a/src/sst/core/impl/interactive/simpleDebug.cc
+++ b/src/sst/core/impl/interactive/simpleDebug.cc
@@ -97,19 +97,21 @@ SimpleDebugger::SimpleDebugger(Params& params) :
     cmdHelp = {
         { "print", "[-rN][<obj>]: print objects in the current level of the object map\n"
                    "\tif -rN is provided print recursive N levels (default N=4)" },
-        { "set", "<obj> <value>: sets an object in the current scope to the provided value;\n"
-                 "\tobject must be a 'fundamental type' e.g. int" },
+        { "set", "<obj> <value>: sets an object in the current scope to the provided value\n"
+                 "\tobject must be a 'fundamental type' (arithmetic or string)\n"
+                 "\t e.g. set mystring hello world" },
         { "watchpoints",
             "Manage watchpoints (with or without tracing)\n"
             "\tA <trigger> can be a <comparison> or a sequence of comparisons combined with a <logicOp>\n"
             "\tE.g. <trigger> = <comparison> or <comparison1> <logicOp> <comparison2> ...\n"
             "\tA <comparision> can be '<var> changed' which checks whether the value has changed\n"
-            "\tor '<var> <comp> <val>' which compares the variable to a given value\n"
-            "\tA <comp> can be <, <=, >, >=, ==, or !=\n"
+            "\tor '<var> <op> <val>' which compares the variable to a given value\n"
+            "\tAn <op> can be <, <=, >, >=, ==, or !=\n"
             "\tA <logicOp> can be && or ||\n"
             "\t'watch' creates a default watchpoint that breaks into an interactive console when triggered\n"
             "\t'trace' creates a watchpoint with a trace buffer to trace a set of variables and trigger an <action>\n"
-            "\tAvailable actions include: interactive, printTrace, checkpoint, set, or printStatus" },
+            "\tAvailable actions include: \n"
+            "\t  interactive, printTrace, checkpoint, set <var> <val>, printStatus, or shutdown" },
         { "watch", "<trigger>: adds watchpoint to the watchlist; breaks into interactive console when triggered\n"
                    "\tExample: watch var1 > 90 && var2 < 100 || var3 changed" },
         { "trace", "<trigger> : <bufferSize> <postDelay> : <var1> ... <varN> : <action>\n"
@@ -117,6 +119,8 @@ SimpleDebugger::SimpleDebugger(Params& params) :
                    "<postDelay>\n"
                    "\tTraces all of the variables specified in the var list and invokes the <action> after postDelay "
                    "when triggered\n"
+                   "\tAvailable actions include: \n"
+                   "\t  interactive, printTrace, checkpoint, set <var> <val>, printStatus, or shutdown\n"
                    "\tExample: trace var1 > 90 || var2 == 100 : 32 4 : size count state : printTrace" },
         { "watchlist", "prints the current list of watchpoints and their associated indices" },
         { "addtracevar", "<watchpointIndex> <var1> ... <varN> : adds the specified variables to the specified "
@@ -1035,9 +1039,12 @@ parseAction(std::vector<std::string>& tokens, size_t& index, Core::Serialization
     }
 #if 0
     else if (action == "heartbeat") {
-        return WatchPoint::HeartbeatAction();
+        return new WatchPoint::HeartbeatWPAction();
     }
 #endif
+    else if ( action == "shutdown" ) {
+        return new WatchPoint::ShutdownWPAction();
+    }
     else {
         return nullptr;
     }

--- a/src/sst/core/impl/interactive/simpleDebug.cc
+++ b/src/sst/core/impl/interactive/simpleDebug.cc
@@ -1078,7 +1078,8 @@ SimpleDebugger::cmd_watch(std::vector<std::string>& tokens)
             printf("Invalid comparison argument passed to watch command\n");
             return;
         }
-        auto* pt = new WatchPoint(name, c);
+        size_t wpIndex = watch_points_.size();
+        auto* pt = new WatchPoint(wpIndex, name, c);
 
 #if 0 // watch variables currently don't trace, but they could automatically
       // trace test vars
@@ -1132,7 +1133,7 @@ SimpleDebugger::cmd_watch(std::vector<std::string>& tokens)
         if (comp) {
             comp->addWatchPoint(pt);
             watch_points_.emplace_back(pt, comp);
-            std::cout << "Added watchpoint #" << watch_points_.size() - 1 << std::endl;
+            std::cout << "Added watchpoint #" << wpIndex << std::endl;
         }
         else {
             printf("Not a component\n");
@@ -1349,7 +1350,8 @@ SimpleDebugger::cmd_trace(std::vector<std::string>& tokens)
         printf("Invalid argument passed in comparison trigger command\n");
         return;
     }
-    auto* pt = new WatchPoint(name, c);
+    size_t wpIndex = watch_points_.size();
+    auto* pt = new WatchPoint(wpIndex, name, c);
 
     // Add additional comparisons and logical ops
     while ( index < tokens.size() ) {
@@ -1429,7 +1431,7 @@ SimpleDebugger::cmd_trace(std::vector<std::string>& tokens)
         if ( comp ) {
             comp->addWatchPoint(pt);
             watch_points_.emplace_back(pt, comp);
-            std::cout << "Added watchpoint #" << watch_points_.size() - 1 << std::endl;
+            std::cout << "Added watchpoint #" << wpIndex << std::endl;
         }
         else {
             std::cout << "Not a component\n";

--- a/src/sst/core/watchPoint.cc
+++ b/src/sst/core/watchPoint.cc
@@ -65,4 +65,10 @@ WatchPoint::heartbeat()
     // Could it just use RTAction?
 }
 
+void
+WatchPoint::simulationShutdown()
+{
+    Simulation_impl::getSimulation()->endSimulation();
+}
+
 } // namespace SST

--- a/src/sst/core/watchPoint.h
+++ b/src/sst/core/watchPoint.h
@@ -38,11 +38,12 @@ public:
         virtual ~Logic()     = default;
     };
 
-    WatchPoint(const std::string& name, Core::Serialization::ObjectMapComparison* obj) :
+    WatchPoint(size_t index, const std::string& name, Core::Serialization::ObjectMapComparison* obj) :
         Clock::HandlerBase::AttachPoint(),
         Event::HandlerBase::AttachPoint(),
         // obj_(obj),
-        name_(name)
+        name_(name),
+        wpIndex(index)
     {
         addComparison(obj);
     }
@@ -275,7 +276,7 @@ public:
         {
             printf("    SetInteractive\n");
             wp->setEnterInteractive(); // Trigger action
-            wp->setInteractiveMsg(format_string("Watch point %s buffer", wp->name_.c_str()));
+            wp->setInteractiveMsg(format_string("  WP%ld: %s ...", wp->wpIndex, wp->name_.c_str()));
             // Note that the interactive action is delayed and
             // we want to be able to print the Trace Buffer there.
             // So, resetTraceBuffer for this case is in handlers
@@ -421,6 +422,7 @@ private:
     std::vector<LogicOp>                                   logicOps_;
     std::string                                            name_;
     Core::Serialization::TraceBuffer*                      tb_ = nullptr;
+    size_t                                                 wpIndex;
 
     unsigned  handler = ALL;
     bool      trigger = false;

--- a/src/sst/core/watchPoint.h
+++ b/src/sst/core/watchPoint.h
@@ -364,6 +364,23 @@ public:
         std::string                     valStr_ = "";
     };
 
+    class ShutdownWPAction : public WPAction
+    {
+    public:
+        ShutdownWPAction() {}
+        virtual ~ShutdownWPAction() = default;
+
+        std::string actionToString() override { return "shutdown"; }
+
+        void invokeAction(WatchPoint* wp) override
+        {
+            wp->printTriggerRecord();
+            printf("  Trigger action shutting down simulation\n");
+            wp->simulationShutdown();
+            return;
+        }
+    };
+
     void setAction(WPAction* action) { wpAction = action; }
 
     void printAction() { std::cout << wpAction->actionToString(); }
@@ -395,6 +412,7 @@ protected:
     void      setCheckpoint();
     void      printStatus();
     void      heartbeat();
+    void      simulationShutdown();
 
 private:
     Core::Serialization::ObjectMapComparison*              obj_;


### PR DESCRIPTION
Adds support for triggering a simulation shutdown from a watchoint trigger test. Also adds a constant watchpoint index to the watchpoint class. Use sst-ext-tests branch of same name for testing.
