### PR TITLE
command line editor for interactive console

### DIFF
--- a/src/sst/core/impl/interactive/Makefile.inc
+++ b/src/sst/core/impl/interactive/Makefile.inc
@@ -5,5 +5,7 @@
 
 sst_core_sources += \
 	impl/interactive/simpleDebug.cc \
-	impl/interactive/simpleDebug.h
+	impl/interactive/simpleDebug.h \
+	impl/interactive/cmdLineEditor.cc \
+	impl/interactive/cmdLineEditor.h
 

--- a/src/sst/core/impl/interactive/cmdLineEditor.cc
+++ b/src/sst/core/impl/interactive/cmdLineEditor.cc
@@ -1,0 +1,152 @@
+// Copyright 2009-2025 NTESS. Under the terms
+// of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2025, NTESS
+// All rights reserved.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+
+#include "sst/core/impl/interactive/cmdLineEditor.h"
+#include <iostream>
+#include <unistd.h>
+
+void CmdLineEditor::setRawMode() {
+    termios rawTerm;
+    // Get current terminal settings
+    tcgetattr(STDIN_FILENO, &originalTerm); 
+    rawTerm = originalTerm;
+    // Disable canonical mode and echoing
+    rawTerm.c_lflag &= ~(ICANON | ECHO);
+    // Apply new settings
+    tcsetattr(STDIN_FILENO, TCSANOW, &rawTerm); 
+}
+void CmdLineEditor::restoreTermMode() {
+    // Restore original settings
+    tcsetattr(STDIN_FILENO, TCSANOW, &originalTerm); 
+}
+bool CmdLineEditor::read2chars(char seq[3]) {
+    bool ok = read(STDIN_FILENO, &seq[0], 1);
+    if (!ok) return 0;
+    ok = read(STDIN_FILENO, &seq[1], 1);
+    seq[2] = '\0';
+    return ok;
+}
+void CmdLineEditor::move_cursor_left() {
+    if (curpos>(int)prompt.size()+1) {
+        std::cout << move_left_ctl << std::flush;
+        curpos--;
+    }
+}
+void CmdLineEditor::move_cursor_right(int slen) {
+    if (curpos < (int)prompt.size() + slen + 1) {
+        std::cout << move_right_ctl << std::flush;
+        curpos++;
+    }
+}
+
+void CmdLineEditor::getline(const std::vector<std::string> &cmdHistory, std::string &newcmd) {
+    
+    // save terminal settings and enable raw mode
+    this->setRawMode();
+    
+    // local edited history
+    std::vector<std::string> history = cmdHistory;
+    history.emplace_back("");           // current command entry
+    int max = history.size() - 1;       // maximum index in history vector
+    int index = max;                    // position in history vector
+
+    // initial empty prompt
+    std::cout << prompt_clear << history[index] << std::flush;
+    curpos = history[index].size() + prompt.size() + 1;
+    
+    // Start checking for keys
+    char c;
+    while (read(STDIN_FILENO, &c, 1) == 1) {
+        if (c == lf_char) {
+            // Done if line feed
+            break; 
+        } else if (c == esc_char) { 
+            // Escape character
+            char seq[3];
+            if (this->read2chars(seq)) {
+                std::string key(seq);
+                if ( key == arrow_up ) {
+                    if (index > 0) index--;
+                    std::cout << prompt_clear << history[index] << std::flush;
+                    curpos = history[index].size() + prompt.size()+ 1;
+                } else if ( key == arrow_dn ) {
+                    if (index < max) index++;
+                    std::cout << prompt_clear << history[index] << std::flush;
+                    curpos = history[index].size() + prompt.size() + 1;
+                } else if ( key == arrow_lf) {
+                    move_cursor_left();
+                } else if ( key == arrow_rt) {
+                    move_cursor_right(history[index].size());
+                }
+            }
+        } else if (c>=32 && c<127) {
+            if (curpos >= max_line_size) continue;
+            // Insert printable character
+            int position = history[index].size()==0 ? 0 : curpos - 1 - prompt.size();
+            if (position < 0 || position > (int) history[index].size() ) {
+                std::cout << prompt_clear << position << std::flush;
+                continue; // something went wrong
+            }
+            history[index].insert(position, 1, c);
+            curpos++;
+            std::cout << prompt_clear << history[index] << esc_ctl << curpos << "G" << std::flush;
+        } else if ( c == bs_char ) {
+            // backspace. Delete a character to the left
+            if (curpos <= (int)prompt.size() + 1 ) continue;
+            curpos--;
+            int position = curpos - prompt.size()-1;
+            if (position < 0 || position >= (int) history[index].size() ) {
+                continue;
+            }
+            history[index].erase(position, 1);
+            std::cout << prompt_clear << history[index] << esc_ctl << curpos << "G" << std::flush;
+        } else if ( c == ctrl_d) {
+            // delete character at cursor
+            int position = curpos - prompt.size()-1;
+            if (position < 0 || position >= (int) history[index].size() ) {
+                continue;
+            }
+            history[index].erase(position,1);
+            std::cout << prompt_clear << history[index] << esc_ctl << curpos << "G" << std::flush;
+        } else if ( c == ctrl_a) {
+            // move cursor to start of line
+            curpos = prompt.size()+ 1;
+            std::cout << prompt_clear << history[index] << esc_ctl << curpos << "G" << std::flush;
+        } else if ( c == ctrl_e ) {
+            // move cursor to the end of the line
+            curpos = history[index].size() + prompt.size()+ 1;
+            std::cout << prompt_clear << history[index] << std::flush;
+        } else if ( c == ctrl_k) {
+            // remove characters from the cursor to the end of the line
+            int position = history[index].size()==0 ? 0 : curpos - 1 - prompt.size();
+            if (position < 0 || position >= (int) history[index].size() ) 
+                continue; // something went wrong
+            int num2erase = history[index].size() - curpos;
+            // std::cout << num2erase << std::endl;
+            if (num2erase < 0 || num2erase > (int) history[index].size())
+                continue; // something else went wrong
+            history[index].erase(position);
+            curpos = history[index].size() + prompt.size()+ 1;
+            std::cout << prompt_clear << history[index] << std::flush;
+        } else if ( c == ctrl_b ) {
+            move_cursor_left();
+        } else if ( c == ctrl_f ) {
+            move_cursor_right(history[index].size());
+        }
+    }
+
+    // Restore original terminal settings
+    this->restoreTermMode();
+
+    // set the new line info
+    newcmd = history[index];
+    std::cout << std::endl;
+}

--- a/src/sst/core/impl/interactive/cmdLineEditor.h
+++ b/src/sst/core/impl/interactive/cmdLineEditor.h
@@ -1,0 +1,66 @@
+// Copyright 2009-2025 NTESS. Under the terms
+// of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2025, NTESS
+// All rights reserved.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+
+#ifndef SST_CORE_IMPL_INTERACTIVE_CMDLINEEDITOR_H
+#define SST_CORE_IMPL_INTERACTIVE_CMDLINEEDITOR_H
+
+#include <termios.h>
+#include <map> 
+#include <string>
+#include <vector>
+
+class CmdLineEditor {
+public:
+    const char esc_char = '\x1B';
+    const char tab_char = '\x9';
+    const char lf_char = '\xa';
+    const char bs_char = '\x7f';
+    const char ctrl_a  = '\x1';
+    const char ctrl_b  = '\x2';
+    const char ctrl_d  = '\x4';
+    const char ctrl_e  = '\x5';
+    const char ctrl_f  = '\x6';
+    const char ctrl_k  = '\xb';
+
+    const std::string arrow_up = "[A";
+    const std::string arrow_dn = "[B";
+    const std::string arrow_rt = "[C";
+    const std::string arrow_lf = "[D";
+    const std::map<const std::string, const std::string> arrowKeyMap = {
+        { arrow_up, "Up"    },
+        { arrow_dn, "Down"  },
+        { arrow_rt, "Right" },
+        { arrow_lf, "Left"  },
+    };
+
+    const std::string clear_line_ctl = "\x1B[2K";
+    const std::string move_left_ctl  = "\x1B[1D";
+    const std::string move_right_ctl = "\x1B[1C";
+    const std::string esc_ctl = "\x1B[";    //"\x1b[5G" moves to column 5
+
+    const std::string prompt = "> ";
+    const std::string prompt_clear = "\x1B[2K\r> ";
+
+    const int max_line_size = 2048;
+
+    void getline(const std::vector<std::string> &cmdHistory, std::string &newcmd);
+
+private:
+    termios originalTerm;
+    int curpos = -1;
+    void setRawMode();
+    void restoreTermMode();
+    bool read2chars(char seq[3]);
+    void move_cursor_left();
+    void move_cursor_right(int slen);
+};
+
+#endif //SST_CORE_IMPL_INTERACTIVE_CMDLINEEDITOR_H

--- a/src/sst/core/impl/interactive/simpleDebug.cc
+++ b/src/sst/core/impl/interactive/simpleDebug.cc
@@ -1481,6 +1481,7 @@ CommandHistoryBuffer::append(std::string s)
 void
 CommandHistoryBuffer::print(int num)
 {
+    if (sz_==0) return;
     int n   = num < sz_ ? num : sz_;
     n       = n <= 0 ? sz_ : n;
     int idx = (nxt_ - n) % sz_;
@@ -1496,6 +1497,7 @@ CommandHistoryBuffer::getBuffer()
 {
     // TODO: combine for print
     stringBuffer_.clear();
+    if (sz_==0) return stringBuffer_;
     int n  = sz_;
     int idx = (nxt_ - n) % sz_;
     if ( idx < 0 ) idx += sz_;

--- a/src/sst/core/impl/interactive/simpleDebug.h
+++ b/src/sst/core/impl/interactive/simpleDebug.h
@@ -15,9 +15,8 @@
 // clang-format off
 #include "sst/core/eli/elementinfo.h"
 #include <sst/core/interactiveConsole.h>
-
 #include "sst/core/serialization/objectMapDeferred.h"
-
+#include "sst/core/impl/interactive/cmdLineEditor.h"
 #include <sst/core/watchPoint.h>
 
 #include <fstream>
@@ -89,10 +88,13 @@ class CommandHistoryBuffer
 {
 public:
     const int MAX_CMDS = 200;
-    CommandHistoryBuffer() { buf_.resize(MAX_CMDS); }
+    CommandHistoryBuffer() { 
+        buf_.resize(MAX_CMDS);
+    }
     void append(std::string s);
     void print(int num);
-    enum BANG_RC { INVALID, ECHO, EXEC, NOP };
+    std::vector<std::string>& getBuffer();
+    enum BANG_RC { INVALID, ECHO_ONLY, EXEC, NOP };
     BANG_RC bang(const std::string& token, std::string& newcmd);
 
 private:
@@ -100,7 +102,8 @@ private:
     int                                              nxt_   = 0;
     int                                              sz_    = 0;
     int                                              count_ = 0;
-    std::vector<std::pair<std::size_t, std::string>> buf_;
+    std::vector<std::pair<std::size_t, std::string>> buf_; 
+    std::vector<std::string> stringBuffer_; 
     // support for ! history retrieval
     bool                                             findEvent(const std::string& s, std::string& newcmd);
     bool                                             findOffset(const std::string& s, std::string& newcmd);
@@ -211,6 +214,9 @@ private:
 
     // Command History
     CommandHistoryBuffer cmdHistoryBuf;
+
+    // Command Line Editor
+    CmdLineEditor cmdLineEditor;
 };
 
 } // namespace SST::IMPL::Interactive

--- a/src/sst/core/impl/interactive/simpleDebug.h
+++ b/src/sst/core/impl/interactive/simpleDebug.h
@@ -102,8 +102,8 @@ private:
     int                                              nxt_   = 0;
     int                                              sz_    = 0;
     int                                              count_ = 0;
-    std::vector<std::pair<std::size_t, std::string>> buf_; 
-    std::vector<std::string> stringBuffer_; 
+    std::vector<std::pair<std::size_t, std::string>> buf_; // actual history with index number
+    std::vector<std::string> stringBuffer_;                // copy of history strings provided to command line editor
     // support for ! history retrieval
     bool                                             findEvent(const std::string& s, std::string& newcmd);
     bool                                             findOffset(const std::string& s, std::string& newcmd);


### PR DESCRIPTION
Added a bash-style command line editor. This is integrated with SST and does not require any external package.  The code detects if input is from the keyboard or from a file/pipe so the only way to test it is to directly interact with the console.

```
> help editing
editing : bash style command line editing using arrow and control keys:
	Up/Down keys: navigate command history
	Left/Right keys: navigate command string
	backspace: delete characters to the left
	ctrl-a: move cursor to beginning of line
	ctrl-b: move cursor to the left
	ctrl-d: delete character at cursor
	ctrl-e: move cursor to end of line
	ctrl-f: move cursor to the right
```

