### PR TITLE
tab auto-completion for interactive console command line

### DIFF
--- a/src/sst/core/impl/interactive/cmdLineEditor.cc
+++ b/src/sst/core/impl/interactive/cmdLineEditor.cc
@@ -10,8 +10,11 @@
 // distribution.
 
 #include "sst/core/impl/interactive/cmdLineEditor.h"
+#include <cctype>
 #include <iostream>
+#include <sstream>
 #include <unistd.h>
+#include "cmdLineEditor.h"
 
 void CmdLineEditor::setRawMode() {
     termios rawTerm;
@@ -47,8 +50,100 @@ void CmdLineEditor::move_cursor_right(int slen) {
     }
 }
 
-void CmdLineEditor::getline(const std::vector<std::string> &cmdHistory, std::string &newcmd) {
-    
+void
+CmdLineEditor::set_cmd_strings(const std::list<std::string>& sortedStrings)
+{  
+    cmdStrings = sortedStrings;
+}
+
+bool CmdLineEditor::selectMatches(const std::list<std::string>& list, const std::string& searchfor, std::vector<std::string>& matches, std::string& newtoken) {
+    std::copy_if(
+        list.begin(), list.end(),
+        std::back_inserter(matches),
+        [&searchfor](const std::string& s) {
+            return matchBeginStringCaseInsensitive(searchfor, s);
+        });
+    if (matches.size()==1) {
+        // unique. Set token to this complete string
+        newtoken = matches[0] + " ";
+        return true;
+    } else if (matches.size()>0) {
+        // list all matching strings
+        std::cout << "\n";
+        for (const std::string& s : matches)
+            std::cout << s << " ";
+        std::cout << std::endl;
+    }
+    return false;
+}
+
+void
+CmdLineEditor::auto_complete(std::string& cmd) {
+    bool hasTrailingSpace = (!cmd.empty() && cmd.back() == ' ');
+    std::istringstream iss(cmd);
+    std::string token;
+    std::vector<std::string> tokens;
+    while (iss >> token)
+        tokens.push_back(token);
+    if (tokens.size() == 0 ) {
+        // list all command strings
+        if (cmdStrings.size()>0) {
+            std::cout << "\n";
+            for ( const std::string& s : cmdStrings )
+                std::cout << s << " ";
+            // TODO std::cout << move_up_ctl << std::flush;
+            // Cleaner for now
+            std::cout << std::endl;
+        }
+    } else if (tokens.size() == 1 && !hasTrailingSpace) {
+        // find all matching command strings starting with tokens[0]
+        std::vector<std::string> matches;
+        bool exact_match = selectMatches(cmdStrings, tokens[0], matches, cmd);
+        if (exact_match) {
+            curpos = cmd.size() + prompt.size() + 1;
+            return;
+        }
+    } else {
+        // after 1st token. provide matching strings in object map
+        if (this->listing_callback_ == nullptr) return;
+        std::list<std::string> listing;
+        listing_callback_(listing);
+        if (listing.size()==0) return;
+        if (hasTrailingSpace) {
+            //list everything
+            std::cout << "\n";
+            for ( const std::string& s : listing ) 
+                std::cout << s << " ";
+            std::cout << std::endl;
+        } else {
+            std::vector<std::string> matches;
+            std::string newtoken;
+            bool exact_match = selectMatches(listing, tokens[tokens.size()-1], matches, newtoken);
+            if (exact_match) {
+                std::stringstream s;
+                for (size_t i=0; i<tokens.size()-1; i++)
+                    s << tokens[i] << " ";
+                s << newtoken;
+                cmd = s.str();
+                curpos = cmd.size() + prompt.size() + 1;
+                return;
+            }
+        }
+    }
+}
+
+
+
+void
+CmdLineEditor::redraw_line(const std::string& s)
+{
+    std::cout << prompt_clear << s << esc_ctl << curpos << "G" << std::flush;
+};
+
+void
+CmdLineEditor::getline(const std::vector<std::string>& cmdHistory, std::string& newcmd)
+{
+
     // save terminal settings and enable raw mode
     this->setRawMode();
     
@@ -97,7 +192,7 @@ void CmdLineEditor::getline(const std::vector<std::string> &cmdHistory, std::str
             }
             history[index].insert(position, 1, c);
             curpos++;
-            std::cout << prompt_clear << history[index] << esc_ctl << curpos << "G" << std::flush;
+            redraw_line(history[index]);
         } else if ( c == bs_char ) {
             // backspace. Delete a character to the left
             if (curpos <= (int)prompt.size() + 1 ) continue;
@@ -107,7 +202,7 @@ void CmdLineEditor::getline(const std::vector<std::string> &cmdHistory, std::str
                 continue;
             }
             history[index].erase(position, 1);
-            std::cout << prompt_clear << history[index] << esc_ctl << curpos << "G" << std::flush;
+            redraw_line(history[index]);
         } else if ( c == ctrl_d) {
             // delete character at cursor
             int position = curpos - prompt.size()-1;
@@ -115,11 +210,11 @@ void CmdLineEditor::getline(const std::vector<std::string> &cmdHistory, std::str
                 continue;
             }
             history[index].erase(position,1);
-            std::cout << prompt_clear << history[index] << esc_ctl << curpos << "G" << std::flush;
+            redraw_line(history[index]);
         } else if ( c == ctrl_a) {
             // move cursor to start of line
             curpos = prompt.size()+ 1;
-            std::cout << prompt_clear << history[index] << esc_ctl << curpos << "G" << std::flush;
+            redraw_line(history[index]);
         } else if ( c == ctrl_e ) {
             // move cursor to the end of the line
             curpos = history[index].size() + prompt.size()+ 1;
@@ -140,6 +235,9 @@ void CmdLineEditor::getline(const std::vector<std::string> &cmdHistory, std::str
             move_cursor_left();
         } else if ( c == ctrl_f ) {
             move_cursor_right(history[index].size());
+        } else if ( c == tab_char ) {
+            auto_complete(history[index]);
+            redraw_line(history[index]);
         }
     }
 

--- a/src/sst/core/impl/interactive/cmdLineEditor.h
+++ b/src/sst/core/impl/interactive/cmdLineEditor.h
@@ -12,6 +12,8 @@
 #ifndef SST_CORE_IMPL_INTERACTIVE_CMDLINEEDITOR_H
 #define SST_CORE_IMPL_INTERACTIVE_CMDLINEEDITOR_H
 
+#include <functional>
+#include <list>
 #include <termios.h>
 #include <map> 
 #include <string>
@@ -45,22 +47,57 @@ public:
     const std::string move_left_ctl  = "\x1B[1D";
     const std::string move_right_ctl = "\x1B[1C";
     const std::string esc_ctl = "\x1B[";    //"\x1b[5G" moves to column 5
+    const std::string move_up_ctl = "\x1B[1F";
 
     const std::string prompt = "> ";
     const std::string prompt_clear = "\x1B[2K\r> ";
 
     const int max_line_size = 2048;
 
+    void redraw_line(const std::string& s);
     void getline(const std::vector<std::string> &cmdHistory, std::string &newcmd);
+
+    // Auto-completino support
+    void set_cmd_strings(const std::list<std::string>& sortedStrings);
+    void set_listing_callback(std::function<void(std::list<std::string>&)> callback) {
+        listing_callback_ = callback;
+    }
 
 private:
     termios originalTerm;
+    std::list<std::string> cmdStrings = {};
+    std::function<void(std::list<std::string>& callback)> listing_callback_ = nullptr;
+
     int curpos = -1;
     void setRawMode();
     void restoreTermMode();
     bool read2chars(char seq[3]);
     void move_cursor_left();
     void move_cursor_right(int slen);
+    void auto_complete(std::string& cmd);
+    bool selectMatches(const std::list<std::string>& list, const std::string& searchfor, std::vector<std::string>& matches, std::string& newcmd);
+
+private:
+    // yet more string helpers
+    static bool compareCharCaseInsensitive(char c1, char c2) {
+        return std::tolower(static_cast<unsigned char>(c1)) == std::tolower(static_cast<unsigned char>(c2));
+    };
+
+    // exact, but case insenstive, match
+    // static bool compareStringCaseInsensitive(const std::string& s1, const std::string& s2) {
+    //     if (s1.length() != s2.length())
+    //         return false;
+    //     return std::equal(s1.begin(), s1.end(), s2.begin(), compareCharCaseInsensitive);
+    // };
+
+    // match if begining of second string matches the first
+    static bool matchBeginStringCaseInsensitive(const std::string& searchfor, const std::string& longstr) {
+        if (longstr.length() < searchfor.length() )
+            return false;
+        std::string matchstr = longstr.substr(0, searchfor.length());
+        return std::equal(searchfor.begin(), searchfor.end(), matchstr.begin(), compareCharCaseInsensitive);
+    }
+
 };
 
 #endif //SST_CORE_IMPL_INTERACTIVE_CMDLINEEDITOR_H

--- a/src/sst/core/impl/interactive/simpleDebug.h
+++ b/src/sst/core/impl/interactive/simpleDebug.h
@@ -134,6 +134,9 @@ public:
 
     void execute(const std::string& msg) override;
 
+    // Callbacks from command line completions
+    void get_listing_strings(std::list<std::string>&);
+
 private:
     // This is the stack of where we are in the class hierarchy.  This
     // is needed because when we advance time, we'll need to delete


### PR DESCRIPTION
This rounds out the fundamental command line controls but adding 'tab' based auto-completion.

Using the tab-key, the first token should provide auto-completion for the list of registered commands.  Anything beyond the first token will be serviced by a callback that provides a list of objects ( equivalent to 'ls' ).

This can only be tested manually because file or piped based input will not go through this code.
