### PR TITLE
Cmd line opt

### DIFF
--- a/src/sst/core/config.cc
+++ b/src/sst/core/config.cc
@@ -522,8 +522,8 @@ Config::insertOptions()
     DEF_SECTION_HEADING("Advanced Options - Debug");
     DEF_ARG("run-mode", 0, "MODE", "Set run mode [ init | run | both (default)]", runMode_, true, false, true);
     DEF_ARG("interactive-console", 0, "ACTION",
-        "[EXPERIMENTAL] Set console to use for interactive mode. NOTE: This currently only works for serial jobs and "
-        "this option will be ignored for parallel runs.",
+        "[EXPERIMENTAL] Set console to use for interactive mode (overrides default console: sst.interactive.simpledebug). "
+        "NOTE: This currently only works for serial jobs and will be ignored for parallel runs.",
         interactive_console_, true, false, false);
     DEF_ARG_OPTVAL("interactive-start", 0, "TIME",
         "[EXPERIMENTAL] Drop into interactive mode at specified simulated time.  If no time is specified, or the time "
@@ -560,6 +560,10 @@ Config::insertOptions()
 
     /* Advanced Features - Checkpoint */
     DEF_SECTION_HEADING("Advanced Options - Checkpointing (EXPERIMENTAL)");
+    DEF_FLAG("checkpoint-enable", 0,
+        "Allows checkpoints to be triggered from the interactive debug console. "
+        "This option is not needed if checkpoint-wall-period, checkpoint-period, or checkpoint-sim-period are used.",
+        checkpoint_enable_, false, false, false);
     DEF_ARG("checkpoint-wall-period", 0, "PERIOD",
         "Set approximate frequency for checkpoints to be generated in terms of wall (real) time. PERIOD can be "
         "specified in hours, minutes, and seconds with "
@@ -649,6 +653,7 @@ Config::setOptionFromModel(const std::string& entryName, const std::string& valu
 bool
 Config::canInitiateCheckpoint()
 {
+    if (checkpoint_enable_.value == true) return true;
     if ( checkpoint_wall_period_.value != 0 ) return true;
     if ( checkpoint_sim_period_.value != "" ) return true;
     return false;

--- a/src/sst/core/config.h
+++ b/src/sst/core/config.h
@@ -579,6 +579,11 @@ private:
 
     /**** Advanced options - Checkpointing ****/
 
+     /**
+     * Enable checkpointing for interactive debug
+     */
+    SST_CONFIG_DECLARE_OPTION(bool, checkpoint_enable, 0, &StandardConfigParsers::flag_set_true);
+
     /**
      * Interval at which to create a checkpoint in wall time
      */

--- a/src/sst/core/impl/interactive/simpleDebug.cc
+++ b/src/sst/core/impl/interactive/simpleDebug.cc
@@ -12,6 +12,8 @@
 // #include "simpleDebug.h"
 #include "sst_config.h"
 
+#include "sst/core/simulation_impl.h"
+
 #include "sst/core/impl/interactive/simpleDebug.h"
 
 #include "sst/core/baseComponent.h"
@@ -122,6 +124,7 @@ SimpleDebugger::SimpleDebugger(Params& params) :
                    "when triggered\n"
                    "\tAvailable actions include: \n"
                    "\t  interactive, printTrace, checkpoint, set <var> <val>, printStatus, or shutdown\n"
+                   "\t  Note: checkpoint action must be enabled at startup via the '--checkpoint-enable' command line option\n"
                    "\tExample: trace var1 > 90 || var2 == 100 : 32 4 : size count state : printTrace" },
         { "watchlist", "prints the current list of watchpoints and their associated indices" },
         { "addtracevar", "<watchpointIndex> <var1> ... <varN> : adds the specified variables to the specified "
@@ -1035,6 +1038,10 @@ parseAction(std::vector<std::string>& tokens, size_t& index, Core::Serialization
         return new WatchPoint::PrintTraceWPAction();
     }
     else if ( action == "checkpoint" ) {
+        if (Simulation_impl::getSimulation()->checkpoint_directory_ == "") {
+            std::cout << "Invalid action: checkpointing not enabled (use --checkpoint-enable cmd line option)\n";
+            return nullptr;
+        }
         return new WatchPoint::CheckpointWPAction();
     }
     else if ( action == "printStatus" ) {

--- a/src/sst/core/interactiveConsole.h
+++ b/src/sst/core/interactiveConsole.h
@@ -13,7 +13,6 @@
 #define SST_CORE_INTERACTIVE_CONSOLE_H
 
 #include "sst/core/action.h"
-#include "sst/core/config.h"
 #include "sst/core/cputimer.h"
 #include "sst/core/eli/elementinfo.h"
 #include "sst/core/output.h"

--- a/src/sst/core/realtime.h
+++ b/src/sst/core/realtime.h
@@ -126,6 +126,7 @@ public:
     InteractiveRealTimeAction();
     void execute() override;
     bool isValidSigalrmAction() override { return false; }
+    bool canInitiateCheckpoint() override { return true; }
 };
 
 /* Wrapper for RealTimeActions that occur on a time interval */

--- a/src/sst/core/simulation.cc
+++ b/src/sst/core/simulation.cc
@@ -940,11 +940,18 @@ Simulation_impl::run()
 
     // Setup interactive mode (only in serial jobs for now)
     if ( num_ranks.rank == 1 && num_ranks.thread == 1 ) {
-        if ( interactive_type_ != "" ) {
+        if ( interactive_type_ != "" ) { 
+            // --interactive-console used to override default
             initialize_interactive_console(interactive_type_);
         }
-        if ( interactive_start_ != "" ) {
-            if ( nullptr == interactive_ ) {
+        else if ((interactive_start_ != "") || (config.sigusr1() == "sst.rt.interactive") || (config.sigusr2() == "sst.rt.interactive")) {
+            // use default interactive console
+            interactive_type_ = "sst.interactive.simpledebug";  
+            initialize_interactive_console(interactive_type_);
+        }
+
+        if ( interactive_start_ != "" ) {          
+            if ( nullptr == interactive_ ) { // Should never get here
                 sim_output.fatal(CALL_INFO, 1,
                     "ERROR: Specified --interactive-start, but did not specify --interactive-mode to set the "
                     "interactive action that should be used.\n");

--- a/src/sst/core/watchPoint.cc
+++ b/src/sst/core/watchPoint.cc
@@ -49,7 +49,12 @@ WatchPoint::getCurrentSimCycle()
 void
 WatchPoint::setCheckpoint()
 {
-    Simulation_impl::getSimulation()->scheduleCheckpoint();
+    if (Simulation_impl::getSimulation()->checkpoint_directory_ == "") {
+        std::cout << "Invalid action: checkpointing not enabled (use --checkpoint-enable cmd line option)\n";
+    }
+    else {
+        Simulation_impl::getSimulation()->scheduleCheckpoint();
+    }
 }
 
 void


### PR DESCRIPTION
New command line option functionality for interactive console:

Interactive console now uses sst.interactive.simpledebug as the default. You only need to use --interactive-console if you want to specify a custom interactive console.
Added --checkpoint-enable flag to enable checkpointing for interactive console checkpoint action
See sst-ext-tests cmd_line_opt branch for tests
