### PR TITLE
watchpoint verbosity control

### DIFF
--- a/src/sst/core/impl/interactive/simpleDebug.cc
+++ b/src/sst/core/impl/interactive/simpleDebug.cc
@@ -105,7 +105,7 @@ SimpleDebugger::SimpleDebugger(Params& params) :
         { "verbose", "[mask]: set verbosity mask or print if no mask specified\n"
                 "\tA mask is used to select which features to enable verbosity.\n"
                 "\tTo turn on all features set the mask to 0xffffffff\n"
-                "\t\t0x10: Show trigger details" },
+                "\t\t16: Show trigger details" },
         { "print", "[-rN][<obj>]: print objects in the current level of the object map\n"
                    "\tif -rN is provided print recursive N levels (default N=4)" },
         { "set", "<obj> <value>: sets an object in the current scope to the provided value\n"
@@ -368,12 +368,19 @@ void
 SimpleDebugger::cmd_verbose(std::vector<std::string>& tokens) {
     if ( tokens.size()>1) {
         try {
-            verbosityLevel = SST::Core::from_string<uint32_t>(tokens[1]);
+            verbosity = SST::Core::from_string<uint32_t>(tokens[1]);
         } catch (std::invalid_argument& e) {
             std::cout << "Invalid mask " << tokens[1] << std::endl;
         }
     }
-    std::cout << "verbose=0x" << std::hex << verbosityLevel << std::endl;
+    std::cout << "verbose=0x" << std::hex << verbosity << std::endl;
+
+    // update watchpoint verbosity
+    for ( auto& x : watch_points_ ) {
+        if (x.first)
+            x.first->setVerbosity(verbosity);
+    }
+
 }
 
 // pwd: print current working directory
@@ -1210,6 +1217,8 @@ SimpleDebugger::cmd_watch(std::vector<std::string>& tokens)
             return;
         }
         else {
+            // Every action gets the same verbosity as the console object
+            actionObj->setVerbosity(verbosity);
             pt->setAction(actionObj);
         }
 
@@ -1756,9 +1765,9 @@ CommandHistoryBuffer::searchAny(const std::string& s, std::string& newcmd)
 
 
 void
-SimpleDebugger::print_verbose(verbosityMask mask, std::string message)
+SimpleDebugger::msg(VERBOSITY_MASK mask, std::string message)
 {
-    if (! static_cast<uint32_t>(mask) && verbosityLevel ) return;
+    if (! static_cast<uint32_t>(mask) && verbosity ) return;
     std::cout << message << std::endl;
 }
 

--- a/src/sst/core/impl/interactive/simpleDebug.cc
+++ b/src/sst/core/impl/interactive/simpleDebug.cc
@@ -1767,7 +1767,7 @@ CommandHistoryBuffer::searchAny(const std::string& s, std::string& newcmd)
 void
 SimpleDebugger::msg(VERBOSITY_MASK mask, std::string message)
 {
-    if (! static_cast<uint32_t>(mask) && verbosity ) return;
+    if ((! static_cast<uint32_t>(mask)) & verbosity ) return;
     std::cout << message << std::endl;
 }
 

--- a/src/sst/core/impl/interactive/simpleDebug.cc
+++ b/src/sst/core/impl/interactive/simpleDebug.cc
@@ -373,7 +373,7 @@ SimpleDebugger::cmd_verbose(std::vector<std::string>& tokens) {
             std::cout << "Invalid mask " << tokens[1] << std::endl;
         }
     }
-    std::cout << "verbose=0x" << std::hex << verbosity << std::endl;
+    std::cout << "verbose=" << verbosity << std::endl;
 
     // update watchpoint verbosity
     for ( auto& x : watch_points_ ) {

--- a/src/sst/core/impl/interactive/simpleDebug.h
+++ b/src/sst/core/impl/interactive/simpleDebug.h
@@ -40,8 +40,8 @@ const std::map<ConsoleCommandGroup, std::string> GroupText {
     { ConsoleCommandGroup::MISC, "Misc" },
 };
 
-enum class verbosityMask : uint32_t {
-    SHOW_TRIGGERS = 0b0001'0000 // 0x10
+enum class VERBOSITY_MASK : uint32_t {
+    WATCHPOINTS = 0b0001'0000 // 0x10
 };
 
 // Encapsulate a console command.
@@ -232,8 +232,8 @@ private:
     CmdLineEditor cmdLineEditor;
 
     // Verbosity controlled console printing
-    uint32_t verbosityLevel = 0;
-    void print_verbose(verbosityMask mask, std::string message);
+    uint32_t verbosity = 0;
+    void msg(VERBOSITY_MASK mask, std::string message);
 };
 
 } // namespace SST::IMPL::Interactive

--- a/src/sst/core/serialization/objectMap.h
+++ b/src/sst/core/serialization/objectMap.h
@@ -132,7 +132,7 @@ public:
 
     virtual bool        compare()         = 0;
     virtual std::string getCurrentValue() = 0;
-    virtual void        print()           = 0;
+    virtual void        print(std::ostream& stream) = 0;
     std::string         getName() { return name_; }
 
     virtual void* getVar() = 0;
@@ -790,13 +790,13 @@ public:
 
     void* getVar() override { return var_; }
 
-    void print() override
+    void print(std::ostream& stream) override
     {
-        std::cout << name_ << " " << getStringFromOp(op_);
+        stream << name_ << " " << getStringFromOp(op_);
         if ( op_ == Op::CHANGED )
-            std::cout << " ";
+            stream << " ";
         else
-            std::cout << " " << SST::Core::to_string(comp_value_) << " ";
+            stream << " " << SST::Core::to_string(comp_value_) << " ";
     }
 
 private:
@@ -958,13 +958,13 @@ public:
 
     void* getVar() override { return var1_; }
 
-    void print() override
+    void print(std::ostream& stream) override
     {
-        std::cout << name_ << " " << getStringFromOp(op_);
+        stream << name_ << " " << getStringFromOp(op_);
         if ( op_ == Op::CHANGED )
-            std::cout << " ";
+            stream << " ";
         else
-            std::cout << " " << name2_ << " ";
+            stream << " " << name2_ << " ";
     }
 
 private:

--- a/src/sst/core/watchPoint.cc
+++ b/src/sst/core/watchPoint.cc
@@ -23,7 +23,7 @@
 namespace SST {
 
 void WatchPoint::InteractiveWPAction::invokeAction(WatchPoint* wp) {
-    msg("    SetInteractive\n");
+    msg("    SetInteractive");
     wp->setEnterInteractive(); // Trigger action
     std::string handlerStr = wp->handlerToString(wp->triggerHandler);
     wp->setInteractiveMsg(format_string("  WP%ld: %s : %s ...", wp->wpIndex, handlerStr.c_str(), wp->name_.c_str()));
@@ -90,7 +90,7 @@ WatchPoint::~WatchPoint() { delete obj_; }
 void WatchPoint::beforeHandler(uintptr_t UNUSED(key), const Event* UNUSED(ev))
 {
     if ( handler & BEFORE_EVENT ) {
-        msg("  Before Event Handler\n");
+        msg("  Before Event Handler");
         check();
         if ( tb_ ) {
 
@@ -110,7 +110,7 @@ void WatchPoint::beforeHandler(uintptr_t UNUSED(key), const Event* UNUSED(ev))
             }
         }
         else {
-            msg("    No trace buffer\n");
+            msg("    No trace buffer");
             if ( trigger ) {
                 triggerHandler = HANDLER::BEFORE_EVENT;
                 wpAction->invokeAction(this);
@@ -124,7 +124,7 @@ void WatchPoint::beforeHandler(uintptr_t UNUSED(key), const Event* UNUSED(ev))
 void WatchPoint::afterHandler(uintptr_t UNUSED(key))
 {
     if ( handler & AFTER_EVENT ) {
-        msg("  After Event Handler\n");
+        msg("  After Event Handler");
         check();
         if ( tb_ ) {
 
@@ -144,7 +144,7 @@ void WatchPoint::afterHandler(uintptr_t UNUSED(key))
             }
         }
         else {
-            msg("    No trace buffer\n");
+            msg("    No trace buffer");
             if ( trigger ) {
                 triggerHandler = HANDLER::AFTER_EVENT;
                 wpAction->invokeAction(this);
@@ -158,7 +158,7 @@ void WatchPoint::afterHandler(uintptr_t UNUSED(key))
 void WatchPoint::beforeHandler(uintptr_t UNUSED(key), const Cycle_t& UNUSED(cycle))
 {
     if ( handler & BEFORE_CLOCK ) {
-        msg("  Before Clock Handler\n");
+        msg("  Before Clock Handler");
         check();
         if ( tb_ ) {
             if ( reset_ && !getInteractive() ) {
@@ -177,7 +177,7 @@ void WatchPoint::beforeHandler(uintptr_t UNUSED(key), const Cycle_t& UNUSED(cycl
             }
         }
         else {
-            msg("    No trace buffer\n");
+            msg("    No trace buffer");
             if ( trigger ) {
                 triggerHandler = HANDLER::BEFORE_CLOCK;
                 wpAction->invokeAction(this);
@@ -191,7 +191,7 @@ void WatchPoint::beforeHandler(uintptr_t UNUSED(key), const Cycle_t& UNUSED(cycl
 void WatchPoint::afterHandler(uintptr_t UNUSED(key), const bool& UNUSED(ret))
     {
         if ( handler & AFTER_CLOCK ) {
-            msg("  After Clock Handler\n");
+            msg("  After Clock Handler");
             check();
             if ( tb_ ) {
                 if ( reset_ && !getInteractive() ) {
@@ -210,7 +210,7 @@ void WatchPoint::afterHandler(uintptr_t UNUSED(key), const bool& UNUSED(ret))
                 }
             }
             else {
-                msg("    No trace buffer\n");
+                msg("    No trace buffer");
                 if ( trigger ) {
                     triggerHandler = HANDLER::AFTER_CLOCK;
                     wpAction->invokeAction(this);

--- a/src/sst/core/watchPoint.cc
+++ b/src/sst/core/watchPoint.cc
@@ -12,18 +12,18 @@
 #include "sst_config.h"
 
 #include "sst/core/watchPoint.h"
-
 #include "sst/core/output.h"
 #include "sst/core/simulation_impl.h"
 #include "sst/core/sst_types.h"
 
 #include <string>
+#include "watchPoint.h"
 
 
 namespace SST {
 
 void WatchPoint::InteractiveWPAction::invokeAction(WatchPoint* wp) {
-    printf("    SetInteractive\n");
+    msg("    SetInteractive\n");
     wp->setEnterInteractive(); // Trigger action
     std::string handlerStr = wp->handlerToString(wp->triggerHandler);
     wp->setInteractiveMsg(format_string("  WP%ld: %s : %s ...", wp->wpIndex, handlerStr.c_str(), wp->name_.c_str()));
@@ -90,7 +90,7 @@ WatchPoint::~WatchPoint() { delete obj_; }
 void WatchPoint::beforeHandler(uintptr_t UNUSED(key), const Event* UNUSED(ev))
 {
     if ( handler & BEFORE_EVENT ) {
-        printf("  Before Event Handler\n");
+        msg("  Before Event Handler\n");
         check();
         if ( tb_ ) {
 
@@ -110,7 +110,7 @@ void WatchPoint::beforeHandler(uintptr_t UNUSED(key), const Event* UNUSED(ev))
             }
         }
         else {
-            printf("    No trace buffer\n");
+            msg("    No trace buffer\n");
             if ( trigger ) {
                 triggerHandler = HANDLER::BEFORE_EVENT;
                 wpAction->invokeAction(this);
@@ -124,7 +124,7 @@ void WatchPoint::beforeHandler(uintptr_t UNUSED(key), const Event* UNUSED(ev))
 void WatchPoint::afterHandler(uintptr_t UNUSED(key))
 {
     if ( handler & AFTER_EVENT ) {
-        printf("  After Event Handler\n");
+        msg("  After Event Handler\n");
         check();
         if ( tb_ ) {
 
@@ -144,7 +144,7 @@ void WatchPoint::afterHandler(uintptr_t UNUSED(key))
             }
         }
         else {
-            printf("    No trace buffer\n");
+            msg("    No trace buffer\n");
             if ( trigger ) {
                 triggerHandler = HANDLER::AFTER_EVENT;
                 wpAction->invokeAction(this);
@@ -158,7 +158,7 @@ void WatchPoint::afterHandler(uintptr_t UNUSED(key))
 void WatchPoint::beforeHandler(uintptr_t UNUSED(key), const Cycle_t& UNUSED(cycle))
 {
     if ( handler & BEFORE_CLOCK ) {
-        printf("  Before Clock Handler\n");
+        msg("  Before Clock Handler\n");
         check();
         if ( tb_ ) {
             if ( reset_ && !getInteractive() ) {
@@ -177,7 +177,7 @@ void WatchPoint::beforeHandler(uintptr_t UNUSED(key), const Cycle_t& UNUSED(cycl
             }
         }
         else {
-            printf("    No trace buffer\n");
+            msg("    No trace buffer\n");
             if ( trigger ) {
                 triggerHandler = HANDLER::BEFORE_CLOCK;
                 wpAction->invokeAction(this);
@@ -191,7 +191,7 @@ void WatchPoint::beforeHandler(uintptr_t UNUSED(key), const Cycle_t& UNUSED(cycl
 void WatchPoint::afterHandler(uintptr_t UNUSED(key), const bool& UNUSED(ret))
     {
         if ( handler & AFTER_CLOCK ) {
-            printf("  After Clock Handler\n");
+            msg("  After Clock Handler\n");
             check();
             if ( tb_ ) {
                 if ( reset_ && !getInteractive() ) {
@@ -210,7 +210,7 @@ void WatchPoint::afterHandler(uintptr_t UNUSED(key), const bool& UNUSED(ret))
                 }
             }
             else {
-                printf("    No trace buffer\n");
+                msg("    No trace buffer\n");
                 if ( trigger ) {
                     triggerHandler = HANDLER::AFTER_CLOCK;
                     wpAction->invokeAction(this);
@@ -249,8 +249,10 @@ void WatchPoint::printTrace()
     }
 }
 
-void WatchPoint::setHandler(unsigned handlerType) { 
-    handler = static_cast<HANDLER>(handlerType); 
+void
+WatchPoint::setHandler(unsigned handlerType)
+{
+    handler = static_cast<HANDLER>(handlerType);
 }
 
 std::string WatchPoint::handlerToString(HANDLER h) {
@@ -304,7 +306,7 @@ void WatchPoint::printWatchpoint()
     printHandler();
     // TODO: print the logic values
     for ( size_t i = 0; i < numCmpObj_; i++ ) { // Print trigger tests
-        cmpObjects_[i]->print();
+        cmpObjects_[i]->print(std::cout);
     }
     std::cout << " : ";
 
@@ -414,36 +416,41 @@ void WatchPoint::check()
     if ( cmpObjects_[0]->compare() ) {
         result = true;
     }
-    std::cout << std::boolalpha;
-    std::cout << "    WatchPoint " << name_.c_str() << " tests:\n";
-    std::cout << "      ";
-    cmpObjects_[0]->print();
-    std::cout << " -> " << result << std::endl;
+    std::stringstream s;
+    s << std::boolalpha;
+    s << "    WatchPoint " << name_.c_str() << " tests:\n";
+    s << "      ";
+    cmpObjects_[0]->print(s);
+    s << " -> " << result << std::endl;
 
     for ( size_t i = 1; i < numCmpObj_; i++ ) {
         bool result2 = false;
         if ( cmpObjects_[i]->compare() ) {
             result2 = true;
         }
-        std::cout << "      ";
-        cmpObjects_[i]->print();
-        std::cout << " -> " << result2 << std::endl;
+        s << "      ";
+        cmpObjects_[i]->print(s);
+        s << " -> " << result2 << std::endl;
         // printf("      comparison%ld = %d\n", i, result2);
 
         if ( logicOps_[i - 1] == LogicOp::AND ) {
             result = result && result2;
-            std::cout << "        AND -> " << result << std::endl;
+            s << "        AND -> " << result << std::endl;
         }
         else if ( logicOps_[i - 1] == LogicOp::OR ) {
             result = result || result2;
-            std::cout << "        OR -> " << result << std::endl;
+            s << "        OR -> " << result << std::endl;
         }
         else {
-            std::cout << "    ERROR: invalid LogicOp\n";
+            s << "    ERROR: invalid LogicOp\n";
             // Should trigger some error?
         }
     }
     if ( result == true ) trigger = true;
+
+    // print the message if verbosity mask matches
+    msg(s.str());
+
 }
 
 } // namespace SST

--- a/src/sst/core/watchPoint.cc
+++ b/src/sst/core/watchPoint.cc
@@ -17,8 +17,6 @@
 #include "sst/core/sst_types.h"
 
 #include <string>
-#include "watchPoint.h"
-
 
 namespace SST {
 

--- a/src/sst/core/watchPoint.h
+++ b/src/sst/core/watchPoint.h
@@ -27,6 +27,8 @@ namespace SST {
 class WatchPoint : public Clock::HandlerBase::AttachPoint, public Event::HandlerBase::AttachPoint
 {
 public:
+    static const uint32_t VMASK = 0x10; // see simpleDebug.h::VERBOSITY_MASK
+
     /**
        Base class for performing comparisons and logic operations for
        determining when the WatchPoint triggers
@@ -48,6 +50,13 @@ public:
         virtual ~WPAction() = default;
         virtual std::string actionToString()             = 0;
         virtual void        invokeAction(WatchPoint* wp) = 0;
+        inline void setVerbosity(uint32_t v) { verbosity = v; }
+    protected:
+        uint32_t verbosity = 0;
+        inline void msg(const std::string& msg) {
+            if (WatchPoint::VMASK & verbosity)
+                std::cout << msg << std::endl;
+        }
     }; //class WPAction
 
     class InteractiveWPAction : public WPAction
@@ -144,6 +153,12 @@ public:
         ALL          = 15
     };
 
+    //TODO can we avoid code duplication in WatchPoint and the WatchPointAction?
+    inline void setVerbosity(uint32_t v) { verbosity=v; wpAction->setVerbosity(v); }
+    inline void msg(const std::string& msg) {
+        if (VMASK & verbosity)
+            std::cout << msg << std::endl;
+    }
     void setHandler(unsigned handlerType);
     std::string handlerToString(HANDLER h);
     void printHandler();
@@ -189,6 +204,7 @@ private:
 
     void setBufferReset();
     void check();
+    uint32_t verbosity = 0;
 
 
 }; //class WatchPoint


### PR DESCRIPTION
The PR provides an initial mechanism to control the verbosity of watchpoints ( and anything else we want to control ) from the debug console. It's important to note that this is not thread safe and that any messages that are printed on the fly during simulation ( e.g. checking for triggers ) is going to be problematic for multi-thread/rank simulations. However, I think we we encapsulate the printing in the `msg` function we can put in an SST::Output object that can also print the rank and thread information conveniently.

```
> help verbose
verbose [mask]: set verbosity mask or print if no mask specified
        A mask is used to select which features to enable verbosity.
        To turn on all features set the mask to 0xffffffff
                16: Show trigger details

> w current_learning_rate_ changed
Added watchpoint #0
> r
NNBatchController[batch_controller:initTraining:1000]: Starting training phase
NNBatchController[batch_controller:initTraining:1000]: ### Training setup
NNBatchController[batch_controller:initTraining:1000]: epochs=10
NNBatchController[batch_controller:initTraining:1000]: X.rows()=20000
NNBatchController[batch_controller:initTraining:1000]: batch_size=128
NNBatchController[batch_controller:initTraining:1000]: train_steps=157
Entering interactive mode at time 24025000 
  WP0: AC : loss/optimizer/current_learning_rate_ ...

> verbose 0
verbose=0x0

> run
Entering interactive mode at time 40041000 
  WP0: AC : loss/optimizer/current_learning_rate_ ...

> verbose 1
verbose=0x1
> r
Entering interactive mode at time 56057000 
  WP0: AC : loss/optimizer/current_learning_rate_ ...

> v 16
verbose=0x10
> r
  Before Event Handler

    WatchPoint loss/optimizer/current_learning_rate_ tests:
      loss/optimizer/current_learning_rate_ CHANGED  -> false

    No trace buffer

  After Event Handler

    WatchPoint loss/optimizer/current_learning_rate_ tests:
      loss/optimizer/current_learning_rate_ CHANGED  -> false

    No trace buffer

  Before Clock Handler

    WatchPoint loss/optimizer/current_learning_rate_ tests:
      loss/optimizer/current_learning_rate_ CHANGED  -> false

    No trace buffer

  After Clock Handler

    WatchPoint loss/optimizer/current_learning_rate_ tests:
      loss/optimizer/current_learning_rate_ CHANGED  -> true

    No trace buffer

    SetInteractive

Entering interactive mode at time 72073000 
  WP0: AC : loss/optimizer/current_learning_rate_ ...
```

( will go back and remove extra \n characters )

More notes in the code review comments


