### PR TITLE
crazy console cursor corrections

### DIFF
--- a/src/sst/core/impl/interactive/cmdLineEditor.h
+++ b/src/sst/core/impl/interactive/cmdLineEditor.h
@@ -12,6 +12,7 @@
 #ifndef SST_CORE_IMPL_INTERACTIVE_CMDLINEEDITOR_H
 #define SST_CORE_IMPL_INTERACTIVE_CMDLINEEDITOR_H
 
+#include <fstream>
 #include <functional>
 #include <list>
 #include <termios.h>
@@ -43,6 +44,7 @@ public:
         { arrow_lf, "Left"  },
     };
 
+
     const std::string clear_line_ctl = "\x1B[2K";
     const std::string move_left_ctl  = "\x1B[1D";
     const std::string move_right_ctl = "\x1B[1C";
@@ -54,6 +56,8 @@ public:
 
     const int max_line_size = 2048;
 
+    CmdLineEditor();
+    virtual ~CmdLineEditor();
     void redraw_line(const std::string& s);
     void getline(const std::vector<std::string> &cmdHistory, std::string &newcmd);
 
@@ -62,6 +66,9 @@ public:
     void set_listing_callback(std::function<void(std::list<std::string>&)> callback) {
         listing_callback_ = callback;
     }
+
+    // debug helper
+    std::ofstream dbgFile;
 
 private:
     termios originalTerm;
@@ -98,6 +105,9 @@ private:
         std::string matchstr = longstr.substr(0, searchfor.length());
         return std::equal(searchfor.begin(), searchfor.end(), matchstr.begin(), compareCharCaseInsensitive);
     }
+
+    // Bug: Why is this escape code injected at the 7th char after verbose printing of 0x...?
+    void flush_bad_escape();
 
 };
 

--- a/src/sst/core/impl/interactive/simpleDebug.h
+++ b/src/sst/core/impl/interactive/simpleDebug.h
@@ -214,6 +214,9 @@ private:
     // Auto-completion toggle
     void cmd_autoComplete(std::vector<std::string>& UNUSED(tokens));
 
+    // Reset terminal
+    void cmd_clear(std::vector<std::string>& UNUSED(tokens));
+
     // LLDB/GDB helper
     void cmd_spinThread(std::vector<std::string>& tokens);
 


### PR DESCRIPTION
I'm using termios.h to detect key presses and to control the command line console but broke a cardinal rule. Namely, when using termios, only use the `read`and `write` functions and do not mix with iostream for console input and output.  The clue was in that when using the 'verbose' command, the failure was caused when writing a 0x... followed by a hex value. Someone that corrupted the termios buffers.  This fix adds a few things:

 - remove std::cout/std::cin functions from the command-line input/output.
 - added #define _KEYB_DEBUG_ to write debug information to a file (for future debug use)
 - added a 'clear' command to the console to allow clearing the screen we we run into other problems.

Tested on my mac and on gizmo.

Could use another set of eyes on the code changes and independent testing.

