### PR TITLE
Cleanup cmd line editor

### DIFF
--- a/src/sst/core/config.cc
+++ b/src/sst/core/config.cc
@@ -522,7 +522,8 @@ Config::insertOptions()
     DEF_SECTION_HEADING("Advanced Options - Debug");
     DEF_ARG("run-mode", 0, "MODE", "Set run mode [ init | run | both (default)]", runMode_, true, false, true);
     DEF_ARG("interactive-console", 0, "ACTION",
-        "[EXPERIMENTAL] Set console to use for interactive mode (overrides default console: sst.interactive.simpledebug). "
+        "[EXPERIMENTAL] Set console to use for interactive mode (overrides default console: "
+        "sst.interactive.simpledebug). "
         "NOTE: This currently only works for serial jobs and will be ignored for parallel runs.",
         interactive_console_, true, false, false);
     DEF_ARG_OPTVAL("interactive-start", 0, "TIME",
@@ -532,9 +533,8 @@ Config::insertOptions()
         "interactive console was set. NOTE: This currently only works for serial jobs and this option will be ignored "
         "for parallel runs.",
         interactive_start_time_, true, false, false);
-    DEF_ARG("replay-file", 0, "FILE",
-        "Specify file for replaying an interactive debug console session.",
-        replay_file_, false);
+    DEF_ARG("replay-file", 0, "FILE", "Specify file for replaying an interactive debug console session.", replay_file_,
+        false);
 #ifdef USE_MEMPOOL
     DEF_ARG("output-undeleted-events", 0, "FILE",
         "file to write information about all undeleted events at the end of simulation (STDOUT and STDERR can be used "
@@ -653,7 +653,7 @@ Config::setOptionFromModel(const std::string& entryName, const std::string& valu
 bool
 Config::canInitiateCheckpoint()
 {
-    if (checkpoint_enable_.value == true) return true;
+    if ( checkpoint_enable_.value == true ) return true;
     if ( checkpoint_wall_period_.value != 0 ) return true;
     if ( checkpoint_sim_period_.value != "" ) return true;
     return false;

--- a/src/sst/core/config.h
+++ b/src/sst/core/config.h
@@ -579,7 +579,7 @@ private:
 
     /**** Advanced options - Checkpointing ****/
 
-     /**
+    /**
      * Enable checkpointing for interactive debug
      */
     SST_CONFIG_DECLARE_OPTION(bool, checkpoint_enable, 0, &StandardConfigParsers::flag_set_true);

--- a/src/sst/core/from_string.h
+++ b/src/sst/core/from_string.h
@@ -14,9 +14,9 @@
 
 #include <iomanip>
 #include <limits>
+#include <sstream>
 #include <stdexcept>
 #include <string>
-#include <sstream>
 #include <type_traits>
 
 namespace SST::Core {
@@ -110,15 +110,16 @@ template <class T>
 std::enable_if_t<!std::is_enum_v<T>, std::string>
 to_string(const T& input)
 {
-    if constexpr ( std::is_floating_point_v<T>) {
+    if constexpr ( std::is_floating_point_v<T> ) {
         std::stringstream s;
-	    T abs_val = input<0 ? -input : input;
-        if (abs_val>(T)10e6 || abs_val < (T)10e-6)
+        T                 abs_val = input < 0 ? -input : input;
+        if ( abs_val > (T)10e6 || abs_val < (T)10e-6 )
             s << std::scientific << std::setprecision(std::numeric_limits<double>::max_digits10) << input;
         else
             s << std::fixed << std::setprecision(std::numeric_limits<double>::max_digits10) << input;
         return s.str().c_str();
-    } else if constexpr ( std::is_arithmetic_v<T> )
+    }
+    else if constexpr ( std::is_arithmetic_v<T> )
         return std::to_string(input);
     else
         return typeid(T).name(); // For now, return a string if the type isn't handled elsewhere

--- a/src/sst/core/impl/interactive/cmdLineEditor.cc
+++ b/src/sst/core/impl/interactive/cmdLineEditor.cc
@@ -10,6 +10,7 @@
 // distribution.
 
 #include "sst/core/impl/interactive/cmdLineEditor.h"
+
 #include <cctype>
 #include <cstring>
 #include <sstream>
@@ -19,100 +20,112 @@
 
 // only use termios read/write functions for console!
 
-CmdLineEditor::CmdLineEditor() {
-    #ifdef _KEYB_DEBUG_
+CmdLineEditor::CmdLineEditor()
+{
+#ifdef _KEYB_DEBUG_
     dbgFile.open("_keyb_debug_.out");
-    #endif
+#endif
 }
 
-CmdLineEditor::~CmdLineEditor() {
-    if (dbgFile.is_open()) dbgFile.close();
-}
-
-int CmdLineEditor::checktty( int rc ) {
-    if (rc == -1 ) {
+int
+CmdLineEditor::checktty(int rc)
+{
+    if ( rc == -1 ) {
         std::string msg("input error: ");
         msg = msg + strerror(errno) + "\n";
-        write(STDOUT_FILENO, msg.c_str(), msg.size());
+        writeStr(msg);
         errno = 0;
     }
     return rc;
 }
 
-int CmdLineEditor::setRawMode() {
+int
+CmdLineEditor::setRawMode()
+{
     termios rawTerm;
-    errno = 0; 
+    errno  = 0;
     int rc = checktty(tcgetattr(STDIN_FILENO, &originalTerm));
-    if (rc) return rc;
+    if ( rc ) return rc;
     rawTerm = originalTerm;
     // Disable canonical mode and echoing
     rawTerm.c_lflag &= ~(ICANON | ECHO);
     // Apply new settings
-    rc = checktty(tcsetattr(STDIN_FILENO, TCSANOW, &rawTerm)); 
+    rc = checktty(tcsetattr(STDIN_FILENO, TCSANOW, &rawTerm));
     return rc;
 }
-int CmdLineEditor::restoreTermMode() {
+
+int
+CmdLineEditor::restoreTermMode()
+{
     // Restore original settings
     int rc = checktty(tcsetattr(STDIN_FILENO, TCSANOW, &originalTerm));
     return rc;
 }
-bool CmdLineEditor::read2chars(char seq[3]) {
+
+bool
+CmdLineEditor::read2chars(char (&seq)[3])
+{
     auto nbytes = read(STDIN_FILENO, &seq[0], 1);
-    if (!nbytes) {
-        #ifdef _KEYB_DEBUG_
+    if ( !nbytes ) {
+#ifdef _KEYB_DEBUG_
         dbgFile << "oops: read2chars tried to read nbytes\n";
-        #endif
+#endif
         return false;
     }
     nbytes = read(STDIN_FILENO, &seq[1], 1);
-    if (!nbytes) {
-        #ifdef _KEYB_DEBUG_
+    if ( !nbytes ) {
+#ifdef _KEYB_DEBUG_
         dbgFile << "oops: read2chars missing 2nd nbyte\n";
-        #endif
+#endif
         return false;
     }
     seq[2] = '\0';
-    return (nbytes>0);
+    return (nbytes > 0);
 }
 
-void CmdLineEditor::move_cursor_left() {
-    if (curpos>(int)prompt.size()+1) {
-        write(STDOUT_FILENO, move_left_ctl.c_str(), move_left_ctl.size());
+void
+CmdLineEditor::move_cursor_left()
+{
+    if ( curpos > (int)prompt.size() + 1 ) {
+        writeStr(move_left_ctl);
         curpos--;
     }
 }
-void CmdLineEditor::move_cursor_right(int slen) {
-    if (curpos < (int)prompt.size() + slen + 1) {
-        write(STDOUT_FILENO, move_right_ctl.c_str(), move_right_ctl.size());
+
+void
+CmdLineEditor::move_cursor_right(int slen)
+{
+    if ( curpos < (int)prompt.size() + slen + 1 ) {
+        writeStr(move_right_ctl);
         curpos++;
     }
 }
 
 void
 CmdLineEditor::set_cmd_strings(const std::list<std::string>& sortedStrings)
-{  
+{
     cmdStrings = sortedStrings;
 }
 
-bool CmdLineEditor::selectMatches(const std::list<std::string>& list, const std::string& searchfor, std::vector<std::string>& matches, std::string& newtoken) {
-    std::copy_if(
-        list.begin(), list.end(),
-        std::back_inserter(matches),
-        [&searchfor](const std::string& s) {
-            return matchBeginStringCaseInsensitive(searchfor, s);
-        });
-    if (matches.size()==1) {
+bool
+CmdLineEditor::selectMatches(const std::list<std::string>& list, const std::string& searchfor,
+    std::vector<std::string>& matches, std::string& newtoken)
+{
+    std::copy_if(list.begin(), list.end(), std::back_inserter(matches),
+        [&searchfor](const std::string& s) { return matchBeginStringCaseInsensitive(searchfor, s); });
+    if ( matches.size() == 1 ) {
         // unique. Set token to this complete string
         newtoken = matches[0] + " ";
         return true;
-    } else if (matches.size()>0) {
+    }
+    else if ( matches.size() > 0 ) {
         // list all matching strings
-        write(STDOUT_FILENO, "\n", 1);
-        for (const std::string& s : matches) {
-            write(STDOUT_FILENO, s.c_str(), s.size());
-            write(STDOUT_FILENO, " ", 1);
+        writeStr("\n");
+        for ( const std::string& s : matches ) {
+            writeStr(s);
+            writeStr(" ");
         }
-        write(STDOUT_FILENO, "\n", 1);
+        writeStr("\n");
     }
     return false;
 }
@@ -121,69 +134,73 @@ void
 CmdLineEditor::flush_bad_escape()
 {
     char c;
-    int max = 4;
-    while (read(STDIN_FILENO, &c, 1)) {
-        if (max-- <= 0 ) break;
-        #ifdef _KEYB_DEBUG_
+    int  max = 4;
+    while ( read(STDIN_FILENO, &c, 1) ) {
+        if ( max-- <= 0 ) break;
+#ifdef _KEYB_DEBUG_
         dbgFile << "Discarding: " << std::hex << (int)c << std::endl;
-        #endif
+#endif
     }
 }
 
 void
-CmdLineEditor::auto_complete(std::string& cmd) {
-    bool hasTrailingSpace = (!cmd.empty() && cmd.back() == ' ');
-    std::istringstream iss(cmd);
-    std::string token;
+CmdLineEditor::auto_complete(std::string& cmd)
+{
+    bool                     hasTrailingSpace = (!cmd.empty() && cmd.back() == ' ');
+    std::istringstream       iss(cmd);
+    std::string              token;
     std::vector<std::string> tokens;
-    while (iss >> token)
+    while ( iss >> token )
         tokens.push_back(token);
-    if (tokens.size() == 0 ) {
+    if ( tokens.size() == 0 ) {
         // list all command strings
-        if (cmdStrings.size()>0) {
-            write(STDOUT_FILENO, "\n", 1);
+        if ( cmdStrings.size() > 0 ) {
+            writeStr("\n");
             for ( const std::string& s : cmdStrings ) {
-                write(STDOUT_FILENO, s.c_str(), s.size());
-                write(STDOUT_FILENO, " ", 1);
+                writeStr(s);
+                writeStr(" ");
             }
-            write(STDOUT_FILENO, "\n", 1);
+            writeStr("\n");
         }
-    } else if (tokens.size() == 1 && !hasTrailingSpace) {
+    }
+    else if ( tokens.size() == 1 && !hasTrailingSpace ) {
         // find all matching command strings starting with tokens[0]
         std::vector<std::string> matches;
-        bool exact_match = selectMatches(cmdStrings, tokens[0], matches, cmd);
-        if (exact_match) {
+        bool                     exact_match = selectMatches(cmdStrings, tokens[0], matches, cmd);
+        if ( exact_match ) {
             curpos = cmd.size() + prompt.size() + 1;
-            #ifdef _KEYB_DEBUG_
-            // dbgFile << "prompt&" << &prompt << "'" << prompt << "'(" << prompt.size() << ") "
-            //          << "cmd&" << &cmd << "'" << cmd << "'(" << cmd.size() << ")" << std::endl;
-            #endif
+#ifdef _KEYB_DEBUG_
+// dbgFile << "prompt&" << &prompt << "'" << prompt << "'(" << prompt.size() << ") "
+//          << "cmd&" << &cmd << "'" << cmd << "'(" << cmd.size() << ")" << std::endl;
+#endif
             return;
         }
-    } else {
+    }
+    else {
         // after 1st token. provide matching strings in object map
-        if (this->listing_callback_ == nullptr) return;
+        if ( this->listing_callback_ == nullptr ) return;
         std::list<std::string> listing;
         listing_callback_(listing);
-        if (listing.size()==0) return;
-        if (hasTrailingSpace) {
-            //list everything
-            write(STDOUT_FILENO, "\n", 1);
+        if ( listing.size() == 0 ) return;
+        if ( hasTrailingSpace ) {
+            // list everything
+            writeStr("\n");
             for ( const std::string& s : listing ) {
-                write(STDOUT_FILENO, s.c_str(), s.size());
-                write(STDOUT_FILENO, " ", 1);
+                writeStr(s);
+                writeStr(" ");
             }
-            write(STDOUT_FILENO, "\n", 1);
-        } else {
+            writeStr("\n");
+        }
+        else {
             std::vector<std::string> matches;
-            std::string newtoken;
-            bool exact_match = selectMatches(listing, tokens[tokens.size()-1], matches, newtoken);
-            if (exact_match) {
+            std::string              newtoken;
+            bool                     exact_match = selectMatches(listing, tokens[tokens.size() - 1], matches, newtoken);
+            if ( exact_match ) {
                 std::stringstream s;
-                for (size_t i=0; i<tokens.size()-1; i++)
+                for ( size_t i = 0; i < tokens.size() - 1; i++ )
                     s << tokens[i] << " ";
                 s << newtoken;
-                cmd = s.str();
+                cmd    = s.str();
                 curpos = cmd.size() + prompt.size() + 1;
                 return;
             }
@@ -191,17 +208,15 @@ CmdLineEditor::auto_complete(std::string& cmd) {
     }
 }
 
-
-
 void
 CmdLineEditor::redraw_line(const std::string& s)
 {
     std::stringstream line;
     line << prompt_clear << s << esc_ctl << curpos << 'G';
-    write(STDOUT_FILENO, line.str().c_str(), line.str().size() );
-    #ifdef _KEYB_DEBUG_
-    //dbgFile << curpos << " " << s.length() << std::endl;
-    #endif
+    writeStr(line.str());
+#ifdef _KEYB_DEBUG_
+// dbgFile << curpos << " " << s.length() << std::endl;
+#endif
 };
 
 void
@@ -209,133 +224,145 @@ CmdLineEditor::getline(const std::vector<std::string>& cmdHistory, std::string& 
 {
 
     // save terminal settings and enable raw mode
-    if (setRawMode() == -1 ) return;
-    
+    if ( setRawMode() == -1 ) return;
+
     // local edited history
     std::vector<std::string> history = cmdHistory;
-    history.emplace_back("");           // current command entry
-    int max = history.size() - 1;       // maximum index in history vector
-    int index = max;                    // position in history vector
+    history.emplace_back("");       // current command entry
+    int max   = history.size() - 1; // maximum index in history vector
+    int index = max;                // position in history vector
 
     // initial empty prompt
     std::stringstream prompt_line;
     prompt_line << prompt_clear << history[index];
-    write(STDOUT_FILENO, prompt_line.str().c_str(), prompt_line.str().size() );
+    writeStr(prompt_line.str());
     curpos = history[index].size() + prompt.size() + 1;
-    
+
     // Start checking for keys
-    char c;
-    int bytesRead = 1;
+    char              c;
+    int               bytesRead = 1;
     std::stringstream oline;
-    while ((bytesRead=read(STDIN_FILENO, &c, 1)) == 1) {
-        #ifdef _KEYB_DEBUG_
+    while ( (bytesRead = read(STDIN_FILENO, &c, 1)) == 1 ) {
+#ifdef _KEYB_DEBUG_
         dbgFile << std::hex << (int)c << std::endl;
-        #endif
-        if (c == lf_char) {   
+#endif
+        if ( c == lf_char ) {
             // Done if line feed
-            break; 
-        } else if (c == esc_char) { 
+            break;
+        }
+        else if ( c == esc_char ) {
             // Escape character
             char seq[3];
-            if (this->read2chars(seq)) {
+            if ( this->read2chars(seq) ) {
                 std::string key(seq);
                 if ( key == arrow_up ) {
-                    if (index > 0) index--;
+                    if ( index > 0 ) index--;
                     oline << prompt_clear << history[index];
-                    write(STDOUT_FILENO, oline.str().c_str(), oline.str().size() );
-                    curpos = history[index].size() + prompt.size()+ 1;
-                } else if ( key == arrow_dn ) {
-                    if (index < max) index++;
-                    oline << prompt_clear << history[index];
-                    write(STDOUT_FILENO, oline.str().c_str(), oline.str().size() );
+                    writeStr(oline.str());
                     curpos = history[index].size() + prompt.size() + 1;
-                } else if ( key == arrow_lf) {
+                }
+                else if ( key == arrow_dn ) {
+                    if ( index < max ) index++;
+                    oline << prompt_clear << history[index];
+                    writeStr(oline.str());
+                    curpos = history[index].size() + prompt.size() + 1;
+                }
+                else if ( key == arrow_lf ) {
                     move_cursor_left();
-                } else if ( key == arrow_rt) {
+                }
+                else if ( key == arrow_rt ) {
                     move_cursor_right(history[index].size());
-                } else {
-                    //unknown escape sequence ( TODO: longer than 2 escape sequences )
-                    #ifdef _KEYB_DEBUG_
+                }
+                else {
+// unknown escape sequence ( TODO: longer than 2 escape sequences )
+#ifdef _KEYB_DEBUG_
                     dbgFile << "Unhandled escape sequence\n" << std::endl;
-                    #endif
+#endif
                     flush_bad_escape();
                 }
-            } else {
-                #ifdef _KEYB_DEBUG_
-                dbgFile << "read2chars failed\n" << std::endl;
-                #endif 
             }
-        } else if (c>=32 && c<127) {
-            if (curpos >= max_line_size) continue;
+            else {
+#ifdef _KEYB_DEBUG_
+                dbgFile << "read2chars failed\n" << std::endl;
+#endif
+            }
+        }
+        else if ( c >= 32 && c < 127 ) {
+            if ( curpos >= max_line_size ) continue;
             // Insert printable character
-            int position = history[index].size()==0 ? 0 : curpos - 1 - prompt.size();
-            if (position < 0 || position > (int) history[index].size() ) {
+            int position = history[index].size() == 0 ? 0 : curpos - 1 - prompt.size();
+            if ( position < 0 || position > (int)history[index].size() ) {
                 oline << prompt_clear << position;
-                write(STDOUT_FILENO, oline.str().c_str(), oline.str().size() );
+                writeStr(oline.str());
                 continue; // something went wrong
             }
             history[index].insert(position, 1, c);
             curpos++;
             redraw_line(history[index]);
-        } else if ( c == bs_char ) {
+        }
+        else if ( c == bs_char ) {
             // backspace. Delete a character to the left
-            if (curpos <= (int)prompt.size() + 1 ) continue;
+            if ( curpos <= (int)prompt.size() + 1 ) continue;
             curpos--;
-            int position = curpos - prompt.size()-1;
-            if (position < 0 || position >= (int) history[index].size() ) {
+            int position = curpos - prompt.size() - 1;
+            if ( position < 0 || position >= (int)history[index].size() ) {
                 continue;
             }
             history[index].erase(position, 1);
             redraw_line(history[index]);
-        } else if ( c == ctrl_d) {
+        }
+        else if ( c == ctrl_d ) {
             // delete character at cursor
-            int position = curpos - prompt.size()-1;
-            if (position < 0 || position >= (int) history[index].size() ) {
+            int position = curpos - prompt.size() - 1;
+            if ( position < 0 || position >= (int)history[index].size() ) {
                 continue;
             }
-            history[index].erase(position,1);
+            history[index].erase(position, 1);
             redraw_line(history[index]);
-        } else if ( c == ctrl_a) {
+        }
+        else if ( c == ctrl_a ) {
             // move cursor to start of line
-            curpos = prompt.size()+ 1;
+            curpos = prompt.size() + 1;
             redraw_line(history[index]);
-        } else if ( c == ctrl_e ) {
+        }
+        else if ( c == ctrl_e ) {
             // move cursor to the end of the line
-            curpos = history[index].size() + prompt.size()+ 1;
+            curpos = history[index].size() + prompt.size() + 1;
             oline << prompt_clear << history[index];
-            write(STDOUT_FILENO, oline.str().c_str(), oline.str().size() );
-        } else if ( c == ctrl_k) {
+            writeStr(oline.str());
+        }
+        else if ( c == ctrl_k ) {
             // remove characters from the cursor to the end of the line
-            int position = history[index].size()==0 ? 0 : curpos - 1 - prompt.size();
-            if (position < 0 || position >= (int) history[index].size() ) 
-                continue; // something went wrong
+            int position = history[index].size() == 0 ? 0 : curpos - 1 - prompt.size();
+            if ( position < 0 || position >= (int)history[index].size() ) continue; // something went wrong
             int num2erase = history[index].size() - curpos;
             // std::cout << num2erase << std::endl;
-            if (num2erase < 0 || num2erase > (int) history[index].size())
-                continue; // something else went wrong
+            if ( num2erase < 0 || num2erase > (int)history[index].size() ) continue; // something else went wrong
             history[index].erase(position);
-            curpos = history[index].size() + prompt.size()+ 1;
+            curpos = history[index].size() + prompt.size() + 1;
             oline << prompt_clear << history[index];
-            write(STDOUT_FILENO, oline.str().c_str(), oline.str().size() );
-        } else if ( c == ctrl_b ) {
+            writeStr(oline.str());
+        }
+        else if ( c == ctrl_b ) {
             move_cursor_left();
-        } else if ( c == ctrl_f ) {
+        }
+        else if ( c == ctrl_f ) {
             move_cursor_right(history[index].size());
-        } else if ( c == tab_char ) {
+        }
+        else if ( c == tab_char ) {
             auto_complete(history[index]);
             redraw_line(history[index]);
         }
-        #ifdef _KEYB_DEBUG_
+#ifdef _KEYB_DEBUG_
         else {
             dbgFile << "Unhandled char " << std::hex << c << std::endl;
-
         }
-        #endif
+#endif
     }
 
-    if (bytesRead == -1 ) {
+    if ( bytesRead == -1 ) {
         oline << "input error: " << strerror(errno);
-        write(STDOUT_FILENO, oline.str().c_str(), oline.str().size() );
+        writeStr(oline.str());
         errno = 0;
     }
 
@@ -344,5 +371,5 @@ CmdLineEditor::getline(const std::vector<std::string>& cmdHistory, std::string& 
 
     // set the new line info
     newcmd = history[index];
-    write(STDOUT_FILENO, "\n", 1);
+    writeStr("\n");
 }

--- a/src/sst/core/impl/interactive/cmdLineEditor.h
+++ b/src/sst/core/impl/interactive/cmdLineEditor.h
@@ -15,79 +15,86 @@
 #include <fstream>
 #include <functional>
 #include <list>
-#include <termios.h>
-#include <map> 
+#include <map>
 #include <string>
+#include <termios.h>
+#include <unistd.h>
 #include <vector>
 
-class CmdLineEditor {
+inline void
+writeStr(const std::string& msg)
+{
+    (void)!write(STDOUT_FILENO, msg.data(), msg.size());
+}
+
+class CmdLineEditor
+{
 public:
-    const char esc_char = '\x1B';
-    const char tab_char = '\x9';
-    const char lf_char = '\xa';
-    const char bs_char = '\x7f';
-    const char ctrl_a  = '\x1';
-    const char ctrl_b  = '\x2';
-    const char ctrl_d  = '\x4';
-    const char ctrl_e  = '\x5';
-    const char ctrl_f  = '\x6';
-    const char ctrl_k  = '\xb';
+    static constexpr char esc_char = '\x1B';
+    static constexpr char tab_char = '\x9';
+    static constexpr char lf_char  = '\xa';
+    static constexpr char bs_char  = '\x7f';
+    static constexpr char ctrl_a   = '\x1';
+    static constexpr char ctrl_b   = '\x2';
+    static constexpr char ctrl_d   = '\x4';
+    static constexpr char ctrl_e   = '\x5';
+    static constexpr char ctrl_f   = '\x6';
+    static constexpr char ctrl_k   = '\xb';
 
-    const std::string arrow_up = "[A";
-    const std::string arrow_dn = "[B";
-    const std::string arrow_rt = "[C";
-    const std::string arrow_lf = "[D";
-    const std::map<const std::string, const std::string> arrowKeyMap = {
-        { arrow_up, "Up"    },
-        { arrow_dn, "Down"  },
+    const std::string                        arrow_up    = "[A";
+    const std::string                        arrow_dn    = "[B";
+    const std::string                        arrow_rt    = "[C";
+    const std::string                        arrow_lf    = "[D";
+    const std::map<std::string, std::string> arrowKeyMap = {
+        { arrow_up, "Up" },
+        { arrow_dn, "Down" },
         { arrow_rt, "Right" },
-        { arrow_lf, "Left"  },
+        { arrow_lf, "Left" },
     };
-
 
     const std::string clear_line_ctl = "\x1B[2K";
     const std::string move_left_ctl  = "\x1B[1D";
     const std::string move_right_ctl = "\x1B[1C";
-    const std::string esc_ctl = "\x1B[";    //"\x1b[5G" moves to column 5
-    const std::string move_up_ctl = "\x1B[1F";
+    const std::string esc_ctl        = "\x1B["; //"\x1b[5G" moves to column 5
+    const std::string move_up_ctl    = "\x1B[1F";
 
-    const std::string prompt = "> ";
+    const std::string prompt       = "> ";
     const std::string prompt_clear = "\x1B[2K\r> ";
 
-    const int max_line_size = 2048;
+    static constexpr int max_line_size = 2048;
 
     CmdLineEditor();
-    virtual ~CmdLineEditor();
+    virtual ~CmdLineEditor() = default;
     void redraw_line(const std::string& s);
-    void getline(const std::vector<std::string> &cmdHistory, std::string &newcmd);
+    void getline(const std::vector<std::string>& cmdHistory, std::string& newcmd);
 
     // Auto-completion support
     void set_cmd_strings(const std::list<std::string>& sortedStrings);
-    void set_listing_callback(std::function<void(std::list<std::string>&)> callback) {
-        listing_callback_ = callback;
-    }
+    void set_listing_callback(std::function<void(std::list<std::string>&)> callback) { listing_callback_ = callback; }
 
     // debug helper
     std::ofstream dbgFile;
 
 private:
-    termios originalTerm;
-    std::list<std::string> cmdStrings = {};
+    termios                                               originalTerm;
+    std::list<std::string>                                cmdStrings        = {};
     std::function<void(std::list<std::string>& callback)> listing_callback_ = nullptr;
 
-    int curpos = -1;
-    int checktty(int rc);
-    int setRawMode();
-    int restoreTermMode();
-    bool read2chars(char seq[3]);
+    int  curpos = -1;
+    int  checktty(int rc);
+    int  setRawMode();
+    int  restoreTermMode();
+    bool read2chars(char (&seq)[3]);
     void move_cursor_left();
     void move_cursor_right(int slen);
     void auto_complete(std::string& cmd);
-    bool selectMatches(const std::list<std::string>& list, const std::string& searchfor, std::vector<std::string>& matches, std::string& newcmd);
+    bool selectMatches(const std::list<std::string>& list, const std::string& searchfor,
+        std::vector<std::string>& matches, std::string& newcmd);
 
 private:
     // yet more string helpers
-    static bool compareCharCaseInsensitive(char c1, char c2) {
+    static bool compareCharCaseInsensitive(char c1, char c2)
+    {
         return std::tolower(static_cast<unsigned char>(c1)) == std::tolower(static_cast<unsigned char>(c2));
     };
 
@@ -99,16 +106,15 @@ private:
     // };
 
     // match if begining of second string matches the first
-    static bool matchBeginStringCaseInsensitive(const std::string& searchfor, const std::string& longstr) {
-        if (longstr.length() < searchfor.length() )
-            return false;
+    static bool matchBeginStringCaseInsensitive(const std::string& searchfor, const std::string& longstr)
+    {
+        if ( longstr.length() < searchfor.length() ) return false;
         std::string matchstr = longstr.substr(0, searchfor.length());
         return std::equal(searchfor.begin(), searchfor.end(), matchstr.begin(), compareCharCaseInsensitive);
     }
 
     // Bug: Why is this escape code injected at the 7th char after verbose printing of 0x...?
     void flush_bad_escape();
-
 };
 
-#endif //SST_CORE_IMPL_INTERACTIVE_CMDLINEEDITOR_H
+#endif // SST_CORE_IMPL_INTERACTIVE_CMDLINEEDITOR_H

--- a/src/sst/core/impl/interactive/simpleDebug.cc
+++ b/src/sst/core/impl/interactive/simpleDebug.cc
@@ -12,14 +12,12 @@
 // #include "simpleDebug.h"
 #include "sst_config.h"
 
-#include "sst/core/simulation_impl.h"
-
 #include "sst/core/impl/interactive/simpleDebug.h"
 
 #include "sst/core/baseComponent.h"
+#include "sst/core/simulation_impl.h"
 #include "sst/core/stringize.h"
 #include "sst/core/timeConverter.h"
-
 
 #include <iostream>
 #include <list>
@@ -105,9 +103,9 @@ SimpleDebugger::SimpleDebugger(Params& params) :
     // Detailed help from some commands. Can also add general things like 'help navigation'
     cmdHelp = {
         { "verbose", "[mask]: set verbosity mask or print if no mask specified\n"
-                "\tA mask is used to select which features to enable verbosity.\n"
-                "\tTo turn on all features set the mask to 0xffffffff\n"
-                "\t\t0x10: Show trigger details" },
+                     "\tA mask is used to select which features to enable verbosity.\n"
+                     "\tTo turn on all features set the mask to 0xffffffff\n"
+                     "\t\t0x10: Show trigger details" },
         { "print", "[-rN][<obj>]: print objects in the current level of the object map\n"
                    "\tif -rN is provided print recursive N levels (default N=4)" },
         { "set", "<obj> <value>: sets an object in the current scope to the provided value\n"
@@ -127,15 +125,16 @@ SimpleDebugger::SimpleDebugger(Params& params) :
             "\t  interactive, printTrace, checkpoint, set <var> <val>, printStatus, or shutdown" },
         { "watch", "<trigger>: adds watchpoint to the watchlist; breaks into interactive console when triggered\n"
                    "\tExample: watch var1 > 90 && var2 < 100 || var3 changed" },
-        { "trace", "<trigger> : <bufferSize> <postDelay> : <var1> ... <varN> : <action>\n"
-                   "\tAdds watchpoint to the watchlist with a trace buffer of <bufferSize> and a post trigger delay of "
-                   "<postDelay>\n"
-                   "\tTraces all of the variables specified in the var list and invokes the <action> after postDelay "
-                   "when triggered\n"
-                   "\tAvailable actions include: \n"
-                   "\t  interactive, printTrace, checkpoint, set <var> <val>, printStatus, or shutdown\n"
-                   "\t  Note: checkpoint action must be enabled at startup via the '--checkpoint-enable' command line option\n"
-                   "\tExample: trace var1 > 90 || var2 == 100 : 32 4 : size count state : printTrace" },
+        { "trace",
+            "<trigger> : <bufferSize> <postDelay> : <var1> ... <varN> : <action>\n"
+            "\tAdds watchpoint to the watchlist with a trace buffer of <bufferSize> and a post trigger delay of "
+            "<postDelay>\n"
+            "\tTraces all of the variables specified in the var list and invokes the <action> after postDelay "
+            "when triggered\n"
+            "\tAvailable actions include: \n"
+            "\t  interactive, printTrace, checkpoint, set <var> <val>, printStatus, or shutdown\n"
+            "\t  Note: checkpoint action must be enabled at startup via the '--checkpoint-enable' command line option\n"
+            "\tExample: trace var1 > 90 || var2 == 100 : 32 4 : size count state : printTrace" },
         { "watchlist", "prints the current list of watchpoints and their associated indices" },
         { "addtracevar", "<watchpointIndex> <var1> ... <varN> : adds the specified variables to the specified "
                          "watchpoint's trace buffer" },
@@ -161,12 +160,12 @@ SimpleDebugger::SimpleDebugger(Params& params) :
                      "\tUp/Down keys: navigate command history\n"
                      "\tLeft/Right keys: navigate command string\n"
                      "\tbackspace: delete characters to the left\n"
-	                 "\ttab: auto-completion\n"
+                     "\ttab: auto-completion\n"
                      "\tctrl-a: move cursor to beginning of line\n"
                      "\tctrl-b: move cursor to the left\n"
                      "\tctrl-d: delete character at cursor\n"
                      "\tctrl-e: move cursor to end of line\n"
-	                 "\tctrl-f: move cursor to the right\n" },
+                     "\tctrl-f: move cursor to the right\n" },
     };
 
     // Command autofill strings
@@ -176,10 +175,10 @@ SimpleDebugger::SimpleDebugger(Params& params) :
         cmdStrings.emplace_back(c.str_short());
     }
     cmdStrings.sort();
-    cmdLineEditor.set_cmd_strings(cmdStrings);  // could also realize as callback to generalize
+    cmdLineEditor.set_cmd_strings(cmdStrings); // could also realize as callback to generalize
 
     // Callback for directory listing strings
-    cmdLineEditor.set_listing_callback([this](std::list<std::string>& vec) { get_listing_strings(vec); } );
+    cmdLineEditor.set_listing_callback([this](std::list<std::string>& vec) { get_listing_strings(vec); });
 }
 
 SimpleDebugger::~SimpleDebugger()
@@ -229,7 +228,7 @@ SimpleDebugger::execute(const std::string& msg)
                 // Standard Input
                 if ( !std::cin ) std::cin.clear(); // fix corrupted input after process resumed
                 std::cout.flush();
-                if (autoCompleteEnable && isatty(STDIN_FILENO))
+                if ( autoCompleteEnable && isatty(STDIN_FILENO) )
                     cmdLineEditor.getline(cmdHistoryBuf.getBuffer(), line);
                 else
                     std::getline(std::cin, line);
@@ -358,37 +357,37 @@ SimpleDebugger::cmd_help(std::vector<std::string>& tokens)
         std::string c = tokens[1];
         if ( cmdHelp.find(c) != cmdHelp.end() ) {
             std::cout << c << " " << cmdHelp.at(c) << std::endl;
-        } else {
-            for (auto& creg : cmdRegistry) {
-                if (creg.match(c)) 
-                    std::cout << creg << std::endl;
+        }
+        else {
+            for ( auto& creg : cmdRegistry ) {
+                if ( creg.match(c) ) std::cout << creg << std::endl;
             }
         }
     }
 }
 
 void
-SimpleDebugger::cmd_verbose(std::vector<std::string>& tokens) {
-    if ( tokens.size()>1) {
+SimpleDebugger::cmd_verbose(std::vector<std::string>& tokens)
+{
+    if ( tokens.size() > 1 ) {
         try {
             verbosity = SST::Core::from_string<uint32_t>(tokens[1]);
-        } catch (std::invalid_argument& e) {
+        }
+        catch ( std::invalid_argument& e ) {
             std::cout << "Invalid mask " << tokens[1] << std::endl;
         }
     }
-    #if 1
+#if 1
     // This messes up the auto-complete keyboard input
     std::cout << "verbose=0x" << std::hex << verbosity << std::endl;
-    #else
+#else
     std::cout << "verbose=" << verbosity << std::endl;
-    #endif
+#endif
 
     // update watchpoint verbosity
     for ( auto& x : watch_points_ ) {
-        if (x.first)
-            x.first->setVerbosity(verbosity);
+        if ( x.first ) x.first->setVerbosity(verbosity);
     }
-
 }
 
 // pwd: print current working directory
@@ -414,8 +413,7 @@ SimpleDebugger::cmd_ls(std::vector<std::string>& UNUSED(tokens))
     auto& vars = obj_->getVariables();
     for ( auto& x : vars ) {
         if ( x.second->isFundamental() ) {
-            std::cout << x.first << " = " << x.second->get() <<
-                " (" <<  x.second->getType() << ")" << std::endl;
+            std::cout << x.first << " = " << x.second->get() << " (" << x.second->getType() << ")" << std::endl;
         }
         else {
             std::cout << x.first.c_str() << "/ (" << x.second->getType() << ")\n";
@@ -424,14 +422,15 @@ SimpleDebugger::cmd_ls(std::vector<std::string>& UNUSED(tokens))
 }
 
 // callback for autofill of object string (similar to ls)
-void SimpleDebugger::get_listing_strings(std::list<std::string>& list) {
+void
+SimpleDebugger::get_listing_strings(std::list<std::string>& list)
+{
     list.clear();
     auto& vars = obj_->getVariables();
     for ( auto& x : vars ) {
         std::stringstream s;
         s << x.first;
-        if (! x.second->isFundamental())
-            s << "/";
+        if ( !x.second->isFundamental() ) s << "/";
         list.emplace_back(s.str());
     }
     list.sort();
@@ -449,7 +448,7 @@ SimpleDebugger::cmd_cd(std::vector<std::string>& tokens)
 
     // Allow for trailing '/'
     std::string selection = tokens[1];
-    if (!selection.empty() && selection.back() == '/') selection.pop_back();
+    if ( !selection.empty() && selection.back() == '/' ) selection.pop_back();
 
     // Check for ..
     if ( selection == ".." ) {
@@ -470,7 +469,7 @@ SimpleDebugger::cmd_cd(std::vector<std::string>& tokens)
     bool                                 loop_detected = false;
     SST::Core::Serialization::ObjectMap* new_obj       = obj_->selectVariable(selection, loop_detected);
     assert(new_obj);
-    if ( !new_obj || (new_obj==obj_) ) {
+    if ( !new_obj || (new_obj == obj_) ) {
         printf("Unknown object in cd command: %s\n", selection.c_str());
         return;
     }
@@ -575,7 +574,7 @@ SimpleDebugger::cmd_set(std::vector<std::string>& tokens)
     bool  loop_detected = false;
     auto* var           = obj_->selectVariable(tokens[1], loop_detected);
     assert(var);
-    if ( !var || (var==obj_) ) {
+    if ( !var || (var == obj_) ) {
         printf("Unknown object in set command: %s\n", tokens[1].c_str());
         return;
     }
@@ -968,7 +967,7 @@ void
 SimpleDebugger::cmd_clear(std::vector<std::string>& UNUSED(tokens))
 {
     // clear screen and move cursor to (0,0)
-    std::cout << "\033[2J\033[1;1H"; 
+    std::cout << "\033[2J\033[1;1H";
 }
 
 // gdb helper. Recommended SST configuration
@@ -1093,7 +1092,7 @@ parseAction(std::vector<std::string>& tokens, size_t& index, Core::Serialization
         return new WatchPoint::PrintTraceWPAction();
     }
     else if ( action == "checkpoint" ) {
-        if (Simulation_impl::getSimulation()->checkpoint_directory_ == "") {
+        if ( Simulation_impl::getSimulation()->checkpoint_directory_ == "" ) {
             std::cout << "Invalid action: checkpointing not enabled (use --checkpoint-enable cmd line option)\n";
             return nullptr;
         }
@@ -1187,7 +1186,7 @@ SimpleDebugger::cmd_watch(std::vector<std::string>& tokens)
             return;
         }
         size_t wpIndex = watch_points_.size();
-        auto* pt = new WatchPoint(wpIndex, name, c);
+        auto*  pt      = new WatchPoint(wpIndex, name, c);
 
 #if 0 // watch variables currently don't trace, but they could automatically
       // trace test vars
@@ -1240,7 +1239,7 @@ SimpleDebugger::cmd_watch(std::vector<std::string>& tokens)
 
         // Get the top level component to set the watch point
         BaseComponent* comp = static_cast<BaseComponent*>(base_comp_->getAddr());
-        if (comp) {
+        if ( comp ) {
             comp->addWatchPoint(pt);
             watch_points_.emplace_back(pt, comp);
             std::cout << "Added watchpoint #" << wpIndex << std::endl;
@@ -1370,7 +1369,7 @@ parseTraceBuffer(std::vector<std::string>& tokens, size_t& index, Core::Serializ
     // Get buffer config
     if ( tokens[index++] != ":" ) {
         std::cout << "Invalid format: trace <trigger> : <bufsize> <postdelay> : <v1> ... "
-               "<vN> : <action>\n";
+                     "<vN> : <action>\n";
         return nullptr;
     }
     // Could check for ":" here and assume that means they just want default
@@ -1403,7 +1402,7 @@ parseTraceBuffer(std::vector<std::string>& tokens, size_t& index, Core::Serializ
 
     if ( tokens[index++] != ":" ) {
         std::cout << "Invalid format: trace <var> <op> <value> : <bufsize> <postdelay> : "
-               "<v1> ... <vN> : <action>\n";
+                     "<v1> ... <vN> : <action>\n";
         return nullptr;
     }
 
@@ -1429,8 +1428,7 @@ parseTraceVar(std::string& tvar, Core::Serialization::ObjectMap* obj, Core::Seri
 
     // Is variable fundamental
     if ( !map->isFundamental() ) {
-        std::cout << "Traces can only be placed on fundamental types; " << tvar <<
-               "is not fundamental\n";
+        std::cout << "Traces can only be placed on fundamental types; " << tvar << "is not fundamental\n";
         return nullptr;
     }
     std::string name = obj->getFullName() + "/" + tvar;
@@ -1461,7 +1459,7 @@ SimpleDebugger::cmd_trace(std::vector<std::string>& tokens)
         return;
     }
     size_t wpIndex = watch_points_.size();
-    auto* pt = new WatchPoint(wpIndex, name, c);
+    auto*  pt      = new WatchPoint(wpIndex, name, c);
 
     // Add additional comparisons and logical ops
     while ( index < tokens.size() ) {
@@ -1593,7 +1591,7 @@ CommandHistoryBuffer::append(std::string s)
 void
 CommandHistoryBuffer::print(int num)
 {
-    if (sz_==0) return;
+    if ( sz_ == 0 ) return;
     int n   = num < sz_ ? num : sz_;
     n       = n <= 0 ? sz_ : n;
     int idx = (nxt_ - n) % sz_;
@@ -1609,8 +1607,8 @@ CommandHistoryBuffer::getBuffer()
 {
     // TODO: combine for print
     stringBuffer_.clear();
-    if (sz_==0) return stringBuffer_;
-    int n  = sz_;
+    if ( sz_ == 0 ) return stringBuffer_;
+    int n   = sz_;
     int idx = (nxt_ - n) % sz_;
     if ( idx < 0 ) idx += sz_;
     for ( int i = 0; i < n; i++ ) {
@@ -1783,7 +1781,7 @@ CommandHistoryBuffer::searchAny(const std::string& s, std::string& newcmd)
 void
 SimpleDebugger::msg(VERBOSITY_MASK mask, std::string message)
 {
-    if ((! static_cast<uint32_t>(mask)) & verbosity ) return;
+    if ( (!static_cast<uint32_t>(mask)) & verbosity ) return;
     std::cout << message << std::endl;
 }
 

--- a/src/sst/core/impl/interactive/simpleDebug.h
+++ b/src/sst/core/impl/interactive/simpleDebug.h
@@ -92,11 +92,9 @@ class CommandHistoryBuffer
 {
 public:
     const int MAX_CMDS = 200;
-    CommandHistoryBuffer() { 
-        buf_.resize(MAX_CMDS);
-    }
-    void append(std::string s);
-    void print(int num);
+    CommandHistoryBuffer() { buf_.resize(MAX_CMDS); }
+    void                      append(std::string s);
+    void                      print(int num);
     std::vector<std::string>& getBuffer();
     enum BANG_RC { INVALID, ECHO_ONLY, EXEC, NOP };
     BANG_RC bang(const std::string& token, std::string& newcmd);
@@ -109,10 +107,10 @@ private:
     std::vector<std::pair<std::size_t, std::string>> buf_; // actual history with index number
     std::vector<std::string> stringBuffer_;                // copy of history strings provided to command line editor
     // support for ! history retrieval
-    bool                                             findEvent(const std::string& s, std::string& newcmd);
-    bool                                             findOffset(const std::string& s, std::string& newcmd);
-    bool                                             searchFirst(const std::string& s, std::string& newcmd);
-    bool                                             searchAny(const std::string& s, std::string& newcmd);
+    bool                     findEvent(const std::string& s, std::string& newcmd);
+    bool                     findOffset(const std::string& s, std::string& newcmd);
+    bool                     searchFirst(const std::string& s, std::string& newcmd);
+    bool                     searchAny(const std::string& s, std::string& newcmd);
 };
 
 class SimpleDebugger : public SST::InteractiveConsole
@@ -179,7 +177,7 @@ private:
 
     // Navigation
     void cmd_help(std::vector<std::string>& UNUSED(tokens));
-    void cmd_verbose(std::vector<std::string>& (tokens));
+    void cmd_verbose(std::vector<std::string>&(tokens));
     void cmd_pwd(std::vector<std::string>& UNUSED(tokens));
     void cmd_ls(std::vector<std::string>& UNUSED(tokens));
     void cmd_cd(std::vector<std::string>& tokens);
@@ -236,7 +234,7 @@ private:
 
     // Verbosity controlled console printing
     uint32_t verbosity = 0;
-    void msg(VERBOSITY_MASK mask, std::string message);
+    void     msg(VERBOSITY_MASK mask, std::string message);
 };
 
 } // namespace SST::IMPL::Interactive

--- a/src/sst/core/serialization/objectMap.cc
+++ b/src/sst/core/serialization/objectMap.cc
@@ -61,8 +61,8 @@ ObjectMap::selectVariable(std::string name, bool& loop_detected)
     loop_detected  = false;
     ObjectMap* var = findVariable(name);
 
-    //TODO Would prefer this be a simple nullptr to avoid confusion (bugs)
-    // If we get nullptr back, then it didn't exist.  Just return this
+    // TODO Would prefer this be a simple nullptr to avoid confusion (bugs)
+    //  If we get nullptr back, then it didn't exist.  Just return this
     if ( nullptr == var ) return this;
 
     // See if this creates a loop
@@ -108,7 +108,7 @@ ObjectMap::get(const std::string& var)
     bool       loop_detected = false;
     ObjectMap* obj           = selectVariable(var, loop_detected);
     assert(obj);
-    if ( nullptr == obj || (obj==this)) return "";
+    if ( nullptr == obj || (obj == this) ) return "";
     if ( !obj->isFundamental() ) return "";
     std::string ret = obj->get();
     obj->selectParent();
@@ -121,7 +121,7 @@ ObjectMap::set(const std::string& var, const std::string& value, bool& found, bo
     bool       loop_detected = false;
     ObjectMap* obj           = selectVariable(var, loop_detected);
     assert(obj);
-    if ( nullptr == obj || obj==this ) {
+    if ( nullptr == obj || obj == this ) {
         found = false;
         return;
     }

--- a/src/sst/core/serialization/objectMap.h
+++ b/src/sst/core/serialization/objectMap.h
@@ -25,7 +25,7 @@
 #include <utility>
 #include <vector>
 
-//#define _OBJMAP_DEBUG_
+// #define _OBJMAP_DEBUG_
 
 namespace SST::Core::Serialization {
 
@@ -133,8 +133,8 @@ public:
 
     virtual ~ObjectMapComparison() = default;
 
-    virtual bool        compare()         = 0;
-    virtual std::string getCurrentValue() = 0;
+    virtual bool        compare()                   = 0;
+    virtual std::string getCurrentValue()           = 0;
     virtual void        print(std::ostream& stream) = 0;
     std::string         getName() { return name_; }
 
@@ -927,7 +927,7 @@ compareType(U1 v, ObjectMapComparison::Op op, U2 w)
 
 // Comparison of two variables with at least one non-arithmetic type
 template <typename U1, typename U2,
-	  std::enable_if_t<( !std::is_same_v<U1, U2> && (!std::is_arithmetic_v<U1> || !std::is_arithmetic_v<U2>) ), int> = true>
+    std::enable_if_t<(!std::is_same_v<U1, U2> && (!std::is_arithmetic_v<U1> || !std::is_arithmetic_v<U2>)), int> = true>
 bool
 compareType(U1 UNUSED(v), ObjectMapComparison::Op UNUSED(op), U2 UNUSED(w))
 {
@@ -1102,12 +1102,12 @@ public:
             // printf("    Sample: post trigger\n");
         }
 
-        // Circular buffer
-        #ifdef _OBJMAP_DEBUG_
+// Circular buffer
+#ifdef _OBJMAP_DEBUG_
         std::cout << "    Sample:" << handler << ": numRecs:" << numRecs_ << " first:" << first_ << " cur:" << cur_
                   << " state:" << state2char.at(state_) << " isOverrun:" << isOverrun_
                   << " samplesLost:" << samplesLost_ << std::endl;
-        #endif
+#endif
         cycleBuffer_[cur_]   = cycle;
         handlerBuffer_[cur_] = handler;
         if ( trigger ) {
@@ -1143,14 +1143,14 @@ public:
             samplesLost_++;
         }
 
-        if ((state_ == TRIGGER) && (postDelay_ == 0)) {
+        if ( (state_ == TRIGGER) && (postDelay_ == 0) ) {
             invokeAction = true;
             std::cout << "    Invoke Action\n";
         }
 
-        if (state_ == POSTTRIGGER) {
+        if ( state_ == POSTTRIGGER ) {
             postCount_++;
-            if (postCount_ >= postDelay_) {
+            if ( postCount_ >= postDelay_ ) {
                 invokeAction = true;
                 std::cout << "    Invoke Action\n";
             }

--- a/src/sst/core/simulation.cc
+++ b/src/sst/core/simulation.cc
@@ -333,7 +333,7 @@ Simulation_impl::Simulation_impl(
 
     interactive_type_  = config.interactive_console();
     interactive_start_ = config.interactive_start_time();
-    replay_file_ = config.replay_file();
+    replay_file_       = config.replay_file();
 }
 
 void
@@ -940,17 +940,18 @@ Simulation_impl::run()
 
     // Setup interactive mode (only in serial jobs for now)
     if ( num_ranks.rank == 1 && num_ranks.thread == 1 ) {
-        if ( interactive_type_ != "" ) { 
+        if ( interactive_type_ != "" ) {
             // --interactive-console used to override default
             initialize_interactive_console(interactive_type_);
         }
-        else if ((interactive_start_ != "") || (config.sigusr1() == "sst.rt.interactive") || (config.sigusr2() == "sst.rt.interactive")) {
+        else if ( (interactive_start_ != "") || (config.sigusr1() == "sst.rt.interactive") ||
+                  (config.sigusr2() == "sst.rt.interactive") ) {
             // use default interactive console
-            interactive_type_ = "sst.interactive.simpledebug";  
+            interactive_type_ = "sst.interactive.simpledebug";
             initialize_interactive_console(interactive_type_);
         }
 
-        if ( interactive_start_ != "" ) {          
+        if ( interactive_start_ != "" ) {
             if ( nullptr == interactive_ ) { // Should never get here
                 sim_output.fatal(CALL_INFO, 1,
                     "ERROR: Specified --interactive-start, but did not specify --interactive-mode to set the "
@@ -2116,8 +2117,7 @@ Simulation_impl::initialize_interactive_console(const std::string& type)
     //     size_t end_index =
     // }
 
-    if (replay_file_.size()>0)
-        p.insert("replayFile", replay_file_);
+    if ( replay_file_.size() > 0 ) p.insert("replayFile", replay_file_);
 
     interactive_ = factory->Create<InteractiveConsole>(actual_type, p);
 }

--- a/src/sst/core/simulation_impl.h
+++ b/src/sst/core/simulation_impl.h
@@ -512,7 +512,7 @@ public:
     RealTimeManager*        real_time_;
     std::string             interactive_type_  = "";
     std::string             interactive_start_ = "";
-    std::string             replay_file_ = "";
+    std::string             replay_file_       = "";
     InteractiveConsole*     interactive_       = nullptr;
     bool                    enter_interactive_ = false;
     std::string             interactive_msg_;

--- a/src/sst/core/testElements/message_mesh/enclosingComponent.h
+++ b/src/sst/core/testElements/message_mesh/enclosingComponent.h
@@ -23,7 +23,6 @@
 
 #include <cstdint>
 #include <vector>
-#include <cstdint>
 
 namespace SST::CoreTest::MessageMesh {
 

--- a/src/sst/core/watchPoint.h
+++ b/src/sst/core/watchPoint.h
@@ -38,7 +38,7 @@ public:
     public:
         virtual bool check() = 0;
         virtual ~Logic()     = default;
-    };// class Logic
+    }; // class Logic
 
     /**
         WatchPoint Action Inner Classes
@@ -47,17 +47,18 @@ public:
     {
     public:
         WPAction() {}
-        virtual ~WPAction() = default;
+        virtual ~WPAction()                              = default;
         virtual std::string actionToString()             = 0;
         virtual void        invokeAction(WatchPoint* wp) = 0;
-        inline void setVerbosity(uint32_t v) { verbosity = v; }
+        inline void         setVerbosity(uint32_t v) { verbosity = v; }
+
     protected:
-        uint32_t verbosity = 0;
-        inline void msg(const std::string& msg) {
-            if (WatchPoint::VMASK & verbosity)
-                std::cout << msg << std::endl;
+        uint32_t    verbosity = 0;
+        inline void msg(const std::string& msg)
+        {
+            if ( WatchPoint::VMASK & verbosity ) std::cout << msg << std::endl;
         }
-    }; //class WPAction
+    }; // class WPAction
 
     class InteractiveWPAction : public WPAction
     {
@@ -65,8 +66,8 @@ public:
         InteractiveWPAction() {}
         virtual ~InteractiveWPAction() = default;
         inline std::string actionToString() override { return "interactive"; }
-        void invokeAction(WatchPoint* wp) override;
-    }; //class InteractiveWPAction
+        void               invokeAction(WatchPoint* wp) override;
+    }; // class InteractiveWPAction
 
     class PrintTraceWPAction : public WPAction
     {
@@ -74,8 +75,8 @@ public:
         PrintTraceWPAction() {}
         virtual ~PrintTraceWPAction() = default;
         inline std::string actionToString() override { return "printTrace"; }
-        void invokeAction(WatchPoint* wp) override;
-    }; //class PrintTraceWPAction
+        void               invokeAction(WatchPoint* wp) override;
+    }; // class PrintTraceWPAction
 
     class CheckpointWPAction : public WPAction
     {
@@ -83,8 +84,8 @@ public:
         CheckpointWPAction() {}
         virtual ~CheckpointWPAction() = default;
         inline std::string actionToString() override { return "checkpoint"; }
-        void invokeAction(WatchPoint* wp) override;
-    }; //class CheckpointWPAction
+        void               invokeAction(WatchPoint* wp) override;
+    }; // class CheckpointWPAction
 
     class PrintStatusWPAction : public WPAction
     {
@@ -92,8 +93,8 @@ public:
         PrintStatusWPAction() {}
         virtual ~PrintStatusWPAction() = default;
         inline std::string actionToString() override { return "printStatus"; }
-        void invokeAction(WatchPoint* wp) override;
-    }; //class PrintStatusWPAction
+        void               invokeAction(WatchPoint* wp) override;
+    }; // class PrintStatusWPAction
 
     class SetVarWPAction : public WPAction
     {
@@ -105,12 +106,13 @@ public:
         {}
         virtual ~SetVarWPAction() = default;
         inline std::string actionToString() override { return "set " + name_ + " " + valStr_; }
-        void invokeAction(WatchPoint* wp) override;
+        void               invokeAction(WatchPoint* wp) override;
+
     private:
         std::string                     name_   = "";
         Core::Serialization::ObjectMap* obj_    = nullptr;
         std::string                     valStr_ = "";
-    }; //class SetVarWPAction
+    }; // class SetVarWPAction
 
     class ShutdownWPAction : public WPAction
     {
@@ -118,8 +120,8 @@ public:
         ShutdownWPAction() {}
         virtual ~ShutdownWPAction() = default;
         inline std::string actionToString() override { return "shutdown"; }
-        void invokeAction(WatchPoint* wp) override;
-    }; //class ShutdownWPAction
+        void               invokeAction(WatchPoint* wp) override;
+    }; // class ShutdownWPAction
 
     // Construction
     WatchPoint(size_t index, const std::string& name, Core::Serialization::ObjectMapComparison* obj);
@@ -139,13 +141,13 @@ public:
 
     // Local
     inline std::string getName() { return name_; }
-    size_t getBufferSize();
-    void printTriggerRecord();
-    void printTrace();
+    size_t             getBufferSize();
+    void               printTriggerRecord();
+    void               printTrace();
 
     enum HANDLER : unsigned {
         // Select which handlers do check and sample
-        NONE = 0,
+        NONE         = 0,
         BEFORE_CLOCK = 1,
         AFTER_CLOCK  = 2,
         BEFORE_EVENT = 4,
@@ -153,22 +155,26 @@ public:
         ALL          = 15
     };
 
-    //TODO can we avoid code duplication in WatchPoint and the WatchPointAction?
-    inline void setVerbosity(uint32_t v) { verbosity=v; wpAction->setVerbosity(v); }
-    inline void msg(const std::string& msg) {
-        if (VMASK & verbosity)
-            std::cout << msg << std::endl;
+    // TODO can we avoid code duplication in WatchPoint and the WatchPointAction?
+    inline void setVerbosity(uint32_t v)
+    {
+        verbosity = v;
+        wpAction->setVerbosity(v);
     }
-    void setHandler(unsigned handlerType);
+    inline void msg(const std::string& msg)
+    {
+        if ( VMASK & verbosity ) std::cout << msg << std::endl;
+    }
+    void        setHandler(unsigned handlerType);
     std::string handlerToString(HANDLER h);
-    void printHandler();
-    void printWatchpoint();
-    void resetTraceBuffer();
+    void        printHandler();
+    void        printWatchpoint();
+    void        resetTraceBuffer();
     inline bool checkReset() { return reset_; }
-    void printAction();
-    void addTraceBuffer(Core::Serialization::TraceBuffer* tb);
-    void addObjectBuffer(Core::Serialization::ObjectBuffer* ob);
-    void addComparison(Core::Serialization::ObjectMapComparison* cmp);
+    void        printAction();
+    void        addTraceBuffer(Core::Serialization::TraceBuffer* tb);
+    void        addObjectBuffer(Core::Serialization::ObjectBuffer* ob);
+    void        addComparison(Core::Serialization::ObjectMapComparison* cmp);
 
     enum LogicOp : unsigned { // Logical Op for trigger tests
         AND       = 0,
@@ -196,18 +202,18 @@ private:
     std::string                                            name_;
     Core::Serialization::TraceBuffer*                      tb_ = nullptr;
     size_t                                                 wpIndex;
-    HANDLER  handler = ALL;
-    bool      trigger = false;
-    HANDLER   triggerHandler = HANDLER::NONE;
-    bool      reset_  = false;
-    WPAction* wpAction;
+    HANDLER                                                handler        = ALL;
+    bool                                                   trigger        = false;
+    HANDLER                                                triggerHandler = HANDLER::NONE;
+    bool                                                   reset_         = false;
+    WPAction*                                              wpAction;
 
-    void setBufferReset();
-    void check();
+    void     setBufferReset();
+    void     check();
     uint32_t verbosity = 0;
 
 
-}; //class WatchPoint
+}; // class WatchPoint
 
 
 } // namespace SST


### PR DESCRIPTION
- Add `writeStr()` function to eliminate repetition
- Remove warning about ignoring return value of `write()` (the exclamation point after `(void)` is needed to remove the warning on all compilers)
- Change some `CmdLineEditor` `const` class members to `static constexpr` (more efficient)
- Make `read2chars` take a reference to an array of 3 characters instead of a pointer, for better type safety
- Make `CmdLineEditor` destructor `=default` since it does not need to explicitly close `dbgFile` member -- the member's own destructor will close it.
- `clang-format` ran on `cmdLineEditor.h` and `cmdLineEditor.cc` and a few other files, to get the CI tests to pass.