### PR TITLE
Implement serializing std::bitset ObjectMap

### DIFF
--- a/src/sst/core/serialization/impl/serialize_bitset.h
+++ b/src/sst/core/serialization/impl/serialize_bitset.h
@@ -25,22 +25,41 @@
 
 namespace SST::Core::Serialization {
 
-// Serialize std::bitset
+// Serialize a std::bitset<N> bit using the pvt::bitset_reference_wrapper<N>
+// This is only used in mapping mode
+template <size_t N>
+class serialize_impl<pvt::bitset_reference_wrapper<N>>
+{
+    void operator()(pvt::bitset_reference_wrapper<N>& t, serializer& ser, ser_opt_t UNUSED(options))
+    {
+        ser.mapper().map_hierarchy_start(
+            ser.getMapName(), new ObjectMapBitReference<typename std::bitset<N>::reference>(t.ref));
+        ser.mapper().map_hierarchy_end();
+    }
+    SST_FRIEND_SERIALIZE();
+};
+
+// Serialize std::bitset<N>
 template <size_t N>
 class serialize_impl<std::bitset<N>>
 {
-    using T = std::bitset<N>;
-    void operator()(T& t, serializer& ser, ser_opt_t UNUSED(options))
+    void operator()(std::bitset<N>& t, serializer& ser, ser_opt_t UNUSED(options))
     {
         switch ( ser.mode() ) {
         case serializer::MAP:
         {
-            // TODO: Should this be mapped as an array? It will have the same problems as std::vector<bool>
+            ser.mapper().map_hierarchy_start(ser.getMapName(), new ObjectMapContainer<std::bitset<N>>(&t));
+
+            // Serialize reference wrappers to each bit
+            for ( size_t i = 0; i < N; ++i )
+                SST_SER_NAME(pvt::bitset_reference_wrapper<N>(t[i]), to_string(i).c_str());
+
+            ser.mapper().map_hierarchy_end();
             break;
         }
 
         default:
-            static_assert(std::is_trivially_copyable_v<T> && std::is_standard_layout_v<T>);
+            static_assert(std::is_trivially_copyable_v<std::bitset<N>> && std::is_standard_layout_v<std::bitset<N>>);
             ser.primitive(t);
             break;
         }
@@ -48,13 +67,13 @@ class serialize_impl<std::bitset<N>>
     SST_FRIEND_SERIALIZE();
 };
 
+// Serialize std::bitset<N>*
 template <size_t N>
 class serialize_impl<std::bitset<N>*>
 {
-    using T = std::bitset<N>;
-    void operator()(T*& t, serializer& ser, ser_opt_t UNUSED(options))
+    void operator()(std::bitset<N>*& t, serializer& ser, ser_opt_t UNUSED(options))
     {
-        if ( ser.mode() == serializer::UNPACK ) t = new T {};
+        if ( ser.mode() == serializer::UNPACK ) t = new std::bitset<N>;
         SST_SER(*t);
     }
     SST_FRIEND_SERIALIZE();

--- a/src/sst/core/serialization/objectMap.cc
+++ b/src/sst/core/serialization/objectMap.cc
@@ -19,9 +19,6 @@
 
 namespace SST::Core::Serialization {
 
-// Static variable instantiation
-const std::multimap<std::string, ObjectMap*> ObjectMap::emptyVars;
-
 std::string
 ObjectMap::getName()
 {

--- a/src/sst/core/serialization/objectMap.h
+++ b/src/sst/core/serialization/objectMap.h
@@ -19,9 +19,12 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstdio>
+#include <exception>
+#include <functional>
 #include <iostream>
 #include <map>
 #include <ostream>
+#include <stdexcept>
 #include <string>
 #include <type_traits>
 #include <typeinfo>
@@ -32,10 +35,29 @@
 
 namespace SST::Core::Serialization {
 
+// Comparison of two keys: If both keys are integers, use numeric comparison, else lexicographic
+struct ObjectMultimapCmp
+{
+    bool operator()(const std::string& a, const std::string& b) const
+    {
+        if ( *a.c_str() && *b.c_str() ) {
+            char* ea;
+            long  na = strtol(a.c_str(), &ea, 10);
+            if ( !*ea ) {
+                char* eb;
+                long  nb = strtol(b.c_str(), &eb, 10);
+                if ( !*eb ) return na < nb;
+            }
+        }
+        return std::less<>()(a, b);
+    }
+};
+
 class ObjectMap;
 class TraceBuffer;
 class ObjectBuffer;
 
+using ObjectMultimap = std::multimap<std::string, ObjectMap*, ObjectMultimapCmp>;
 
 // class ObjectMapComparison_impl<T>;
 /**
@@ -159,14 +181,6 @@ class ObjectMap
 {
 protected:
     /**
-       Static empty variable map for use by versions that don't have
-       variables (i.e. are fundamentals or classes treated as
-       fundamentals.  This is needed because getVariables() returns a
-       reference to the map.
-    */
-    static const std::multimap<std::string, ObjectMap*> emptyVars;
-
-    /**
        Metadata object for walking the object hierarchy.  When this
        object is selected by a parent object, a metadata object will
        be added.  The metadata contains a pointer to the parent and
@@ -218,7 +232,7 @@ private:
        longer needed and the object will delete itself if refCount_
        reaches 0.
      */
-    int32_t refCount_ = 1;
+    size_t refCount_ = 1;
 
 public:
     /**
@@ -297,7 +311,17 @@ public:
        ObjectMap's child variables. Fundamental types will return the
        same empty map.
      */
-    virtual const std::multimap<std::string, ObjectMap*>& getVariables() { return emptyVars; }
+    virtual const ObjectMultimap& getVariables()
+    {
+        /**
+           Static empty variable map for use by versions that don't have
+           variables (i.e. are fundamentals or classes treated as
+           fundamentals.  This is needed because getVariables() returns a
+           reference to the map.
+        */
+        static ObjectMultimap emptyVars;
+        return emptyVars;
+    }
 
     /**
        Increment the reference counter for this ObjectMap. When
@@ -399,7 +423,7 @@ public:
        templated child classes for fundamentals will know how to
        convert the string to a value of the approproprite type.  NOTE:
        this function is only valid for ObjectMaps that represent
-       fundamental types or classes treated as fundamentatl types
+       fundamental types or classes treated as fundamental types
        (i.e. isFundamental() returns true).
 
        @param value Value to set the object to, represented as a string
@@ -577,7 +601,7 @@ protected:
     /**
        Map that child ObjectMaps are stored in
      */
-    std::multimap<std::string, ObjectMap*> variables_;
+    ObjectMultimap variables_;
 
     /**
        Default constructor
@@ -623,7 +647,7 @@ public:
        child variables. pair.first is the name of the variable in the
        context of this object. pair.second is a pointer to the ObjectMap.
      */
-    const std::multimap<std::string, ObjectMap*>& getVariables() override { return variables_; }
+    const ObjectMultimap& getVariables() override { return variables_; }
 };
 
 
@@ -1280,21 +1304,14 @@ public:
 
     virtual bool checkValue(const std::string& value) override
     {
-        bool ret = false;
         try {
-            T v = SST::Core::from_string<T>(value);
-            ret = static_cast<bool>(v);
+            SST::Core::from_string<T>(value);
+            return true;
         }
-        catch ( const std::invalid_argument& e ) {
-            std::cerr << "Error: Invalid value: " << value << std::endl;
+        catch ( const std::exception& e ) {
+            std::cerr << e.what() << ": " << value << std::endl;
             return false;
         }
-        catch ( const std::out_of_range& e ) {
-            std::cerr << "Error: Value is out of range: " << value << std::endl;
-            return false;
-        }
-        ret = true;
-        return ret;
     }
 
     /**
@@ -1314,7 +1331,7 @@ public:
 
        @return Address of variable
      */
-    void* getAddr() override { return (void*)addr_; }
+    void* getAddr() override { return addr_; }
 
     explicit ObjectMapFundamental(T* addr) :
         addr_(addr)
@@ -1489,6 +1506,30 @@ public:
         size(size)
     {}
     ~ObjectMapArray() override = default;
+};
+
+// Object Map for bit references represented by std::bitset<N>::reference and std::vector<bool>::reference
+template <typename REF>
+class ObjectMapBitReference : public ObjectMapFundamental<bool>
+{
+    REF ref;
+
+public:
+    explicit ObjectMapBitReference(REF ref) :
+        ObjectMapFundamental(nullptr),
+        ref(ref)
+    {}
+    std::string get() override { return ref ? "1" : "0"; }
+    void        set_impl(const std::string& value) override
+    {
+        try {
+            ref = from_string<bool>(value);
+        }
+        catch ( const std::exception& e ) {
+            std::cerr << e.what() << std::endl;
+        }
+    }
+    ~ObjectMapBitReference() override = default;
 };
 
 

--- a/src/sst/core/serialization/objectMapDeferred.h
+++ b/src/sst/core/serialization/objectMapDeferred.h
@@ -42,7 +42,7 @@ public:
 
        @return nullptr
      */
-    void* getAddr() override { return static_cast<void*>(addr_); }
+    void* getAddr() override { return addr_; }
 
 
     /**
@@ -52,7 +52,7 @@ public:
        ObjectMap's child variables. pair.first is the name of the
        variable in the context of this object.
      */
-    const std::multimap<std::string, ObjectMap*>& getVariables() override { return obj_->getVariables(); }
+    const ObjectMultimap& getVariables() override { return obj_->getVariables(); }
 
     /**
        For the Deferred Build, the only variable that gets added will
@@ -87,7 +87,7 @@ protected:
     void activate_callback() override
     {
         // On activate, we need to create the ObjectMap data structure
-        if ( obj_ != nullptr ) return;
+        if ( obj_ ) return;
 
         SST::Core::Serialization::serializer ser;
         ser.enable_pointer_tracking();
@@ -117,7 +117,7 @@ private:
 
     /**
        Type of the variable as given by the demangled version of
-       typeif<T>.name() for the type.
+       typeid(T).name() for the type.
      */
     std::string type_ = "";
 };

--- a/src/sst/core/serialization/serialize.h
+++ b/src/sst/core/serialization/serialize.h
@@ -22,6 +22,7 @@
 #undef SST_INCLUDING_SERIALIZE_H
 
 #include <atomic>
+#include <bitset>
 #include <cstdint>
 #include <iostream>
 #include <type_traits>
@@ -86,9 +87,22 @@ struct SerOption
 namespace Core::Serialization {
 
 namespace pvt {
+
 template <typename T>
 void sst_ser_object(serializer& ser, T&& obj, ser_opt_t options, const char* name);
-}
+
+// Proxy struct which represents a std::bitset<N>::reference bit reference wrapper similar to std::reference_wrapper.
+// This proxy is needed in order for us to partially specialize serialize_impl for the std::bitset<N>::reference type.
+template <size_t N>
+struct bitset_reference_wrapper
+{
+    typename std::bitset<N>::reference ref;
+    explicit bitset_reference_wrapper(typename std::bitset<N>::reference ref) :
+        ref(std::move(ref))
+    {}
+};
+
+} // namespace pvt
 
 // get_ptr() returns reference to argument if it's a pointer, else address of argument
 template <typename T>
@@ -100,7 +114,6 @@ get_ptr(T& t)
     else
         return &t;
 }
-
 
 /**
    Base serialize class.


### PR DESCRIPTION
This adds support for `std::bitset` `ObjectMap`. 

A complication, is that individual bits cannot have pointers to them, and proxy reference objects have to be used.

The implementation is based on `ObjectMapFundamental`, but the `get()` and `set_impl()` methods are overriden. Some `ObjectMapFundamental` functions may need to call these possibly-overriden methods, to make certain functions work.

I am able to `cd` into `std::bitset`, and I am able to `set` its elements to `bool`-compatible values (`0`, `1`, `true`, `false`, `on`, `off`, etc.).

A similar change will be needed for `std::vector<bool>`, since it uses proxy objects for compressed bits, instead of individually addressable `bool` elements.

This PR also changes the `ObjectMap` comparison function to use numeric comparison if two keys (names) are integers, so when you `ls` an object which has all-numeric keys, like array subscripts, they are listed in numerical order.
