### PR TITLE
Handle signals before creating checkpoing directory and fail immediat…

### DIFF
--- a/src/sst/core/checkpointAction.cc
+++ b/src/sst/core/checkpointAction.cc
@@ -332,11 +332,10 @@ initializeCheckpointInfrastructure(Config* cfg, bool rt_can_ckpt, int myRank)
 
     if ( myRank == 0 ) {
         // Verify prefix format (no '/')
-        const std::string prefix = cfg->checkpoint_prefix();
-        size_t foundPos = prefix.find('/');
-        if (foundPos != std::string::npos) {
-            throw std::invalid_argument(
-                "Invalid checkpoint prefix: " + prefix);
+        const std::string prefix   = cfg->checkpoint_prefix();
+        size_t            foundPos = prefix.find('/');
+        if ( foundPos != std::string::npos ) {
+            throw std::invalid_argument("Invalid checkpoint prefix: " + prefix);
         }
 
         // Create checkpoint directory path

--- a/src/sst/core/checkpointAction.cc
+++ b/src/sst/core/checkpointAction.cc
@@ -341,7 +341,7 @@ initializeCheckpointInfrastructure(Config* cfg, bool rt_can_ckpt, int myRank)
         // Create checkpoint directory path
         SST::Util::Filesystem& fs = Simulation_impl::getSimulation()->filesystem;
         checkpoint_dir_name       = fs.createUniqueDirectory(cfg->checkpoint_prefix());
-        //std::cout << "Checkpoint directory: " << checkpoint_dir_name << std::endl;
+        // std::cout << "Checkpoint directory: " << checkpoint_dir_name << std::endl;
     }
 
 #ifdef SST_CONFIG_HAVE_MPI

--- a/src/sst/core/checkpointAction.cc
+++ b/src/sst/core/checkpointAction.cc
@@ -341,7 +341,7 @@ initializeCheckpointInfrastructure(Config* cfg, bool rt_can_ckpt, int myRank)
         // Create checkpoint directory path
         SST::Util::Filesystem& fs = Simulation_impl::getSimulation()->filesystem;
         checkpoint_dir_name       = fs.createUniqueDirectory(cfg->checkpoint_prefix());
-        std::cout << "Checkpoint directory: " << checkpoint_dir_name << std::endl;
+        //std::cout << "Checkpoint directory: " << checkpoint_dir_name << std::endl;
     }
 
 #ifdef SST_CONFIG_HAVE_MPI

--- a/src/sst/core/checkpointAction.cc
+++ b/src/sst/core/checkpointAction.cc
@@ -331,8 +331,18 @@ initializeCheckpointInfrastructure(Config* cfg, bool rt_can_ckpt, int myRank)
     std::string checkpoint_dir_name = "";
 
     if ( myRank == 0 ) {
+        // Verify prefix format (no '/')
+        const std::string prefix = cfg->checkpoint_prefix();
+        size_t foundPos = prefix.find('/');
+        if (foundPos != std::string::npos) {
+            throw std::invalid_argument(
+                "Invalid checkpoint prefix: " + prefix);
+        }
+
+        // Create checkpoint directory path
         SST::Util::Filesystem& fs = Simulation_impl::getSimulation()->filesystem;
         checkpoint_dir_name       = fs.createUniqueDirectory(cfg->checkpoint_prefix());
+        std::cout << "Checkpoint directory: " << checkpoint_dir_name << std::endl;
     }
 
 #ifdef SST_CONFIG_HAVE_MPI

--- a/src/sst/core/config.cc
+++ b/src/sst/core/config.cc
@@ -660,10 +660,6 @@ Config::canInitiateCheckpoint()
     if ( checkpoint_enable_.value == true ) return true;
     if ( checkpoint_wall_period_.value != 0 ) return true;
     if ( checkpoint_sim_period_.value != "" ) return true;
-    printf("checkpoint_enable_.value = %d\n", checkpoint_enable_.value);
-    printf("sigalrm_.value = %s\n", sigalrm_.value.c_str());
-    printf("sigusr1_.value = %s\n", sigusr1_.value.c_str());
-    // Needs to check for sigusr, sigalrm
     return false;
 }
 

--- a/src/sst/core/config.cc
+++ b/src/sst/core/config.cc
@@ -660,6 +660,10 @@ Config::canInitiateCheckpoint()
     if ( checkpoint_enable_.value == true ) return true;
     if ( checkpoint_wall_period_.value != 0 ) return true;
     if ( checkpoint_sim_period_.value != "" ) return true;
+    printf("checkpoint_enable_.value = %d\n", checkpoint_enable_.value);
+    printf("sigalrm_.value = %s\n", sigalrm_.value.c_str());
+    printf("sigusr1_.value = %s\n", sigusr1_.value.c_str());
+    // Needs to check for sigusr, sigalrm
     return false;
 }
 

--- a/src/sst/core/main.cc
+++ b/src/sst/core/main.cc
@@ -468,6 +468,11 @@ start_simulation(uint32_t tid, SimThreadInfo_t& info, Core::ThreadSafe::Barrier&
         Simulation_impl::createSimulation(info.myRank, info.world_size, restart, currentSimCycle, currentPriority);
     double start_run = 0.0;
 
+    // Setup the real time actions (all of these have to be defined on
+    // the command-line or SDL file, they will not be checkpointed and
+    // restored
+    sim->setupSimActions();
+
     // Thread zero needs to initialize the checkpoint data structures
     // if any checkpointing options were turned on.  This will return
     // an empty string if checkpointing was not enabled.
@@ -528,12 +533,13 @@ start_simulation(uint32_t tid, SimThreadInfo_t& info, Core::ThreadSafe::Barrier&
 
     } // if ( restart )
 
-
+#if 0  // skk Move this before checkpoint infrastructure setup
     // Setup the real time actions (all of these have to be defined on
     // the command-line or SDL file, they will not be checkpointed and
     // restored
     sim->setupSimActions();
-
+    printf(" After setupSimActions, realtime can checkpoint = %d\n", sim->real_time_->canInitiateCheckpoint());
+#endif
 
     if ( !restart ) {
 

--- a/src/sst/core/main.cc
+++ b/src/sst/core/main.cc
@@ -533,7 +533,7 @@ start_simulation(uint32_t tid, SimThreadInfo_t& info, Core::ThreadSafe::Barrier&
 
     } // if ( restart )
 
-#if 0  // skk Move this before checkpoint infrastructure setup
+#if 0 // skk Move this before checkpoint infrastructure setup
     // Setup the real time actions (all of these have to be defined on
     // the command-line or SDL file, they will not be checkpointed and
     // restored

--- a/src/sst/core/realtime.h
+++ b/src/sst/core/realtime.h
@@ -127,7 +127,9 @@ public:
     InteractiveRealTimeAction();
     void execute() override;
     bool isValidSigalrmAction() override { return false; }
-    bool canInitiateCheckpoint() override { return true; }
+    // Separate --checkpoint-enable flag is currently used to control checkpointing for interactive console
+    // If we set canInitiateCheckpoint to true here, it will ALWAYS set up checkpointing and the flag is unnecessary
+    bool canInitiateCheckpoint() override { return false; }
 };
 
 /* Wrapper for RealTimeActions that occur on a time interval */

--- a/tests/testsuite_default_RealTime.py
+++ b/tests/testsuite_default_RealTime.py
@@ -170,7 +170,7 @@ class testcase_Signals(SSTTestCase):
         # Run test
         sdlfile = "{0}/test_RealTime.py".format(testsuitedir)
         outfile = "{0}/test_RealTime_heartbeat.out".format(outdir)
-        self.run_sst(sdlfile, outfile, other_args="--exit-after=6s --heartbeat-wall-period=1")
+        self.run_sst(sdlfile, outfile, other_args="--exit-after=6s --heartbeat-wall-period=2")
 
         # Cannot diff test output because times may differ
         # Check for at least 5 heartbeat messages
@@ -190,10 +190,10 @@ class testcase_Signals(SSTTestCase):
         ranks = testing_check_get_num_ranks()
         threads = testing_check_get_num_threads()
         num_para = threads * ranks
-        num_lines = 126 + 2*num_para # basic heartbeat (>25) + exit messages (1 + 2*para) + Component Finished messages (100)
+        num_lines = 116 + 2*num_para # basic heartbeat (>25) + exit messages (1 + 2*para) + Component Finished messages (100)
         if ranks > 1:
             num_lines += 10 # Extra heartbeat output for MPI
-        self.assertTrue(hb_count >= 5, "Heartbeat count incorrect, should be at least 5, found {0} in {1}".format(hb_count,outfile))
+        self.assertTrue(hb_count >= 2, "Heartbeat count incorrect, should be at least 2, found {0} in {1}".format(hb_count,outfile))
         self.assertTrue(exit_count == num_para, "Exit message count incorrect, should be {0}, found {1} in {2}".format(num_para,exit_count,outfile))
         self.assertTrue(line_count >= num_lines, "Line count incorrect, should be {0}, found {1} in {2}".format(num_lines,line_count,outfile))
 


### PR DESCRIPTION
Fixes support for --checkpoint-prefix when used with signals and errors out if a path is used with --checkpoint-prefix instead of a directory name.

Test with sst-ext-tests branch ckptprefixmerge.