### PR TITLE
User Defined Commands for Interactive Console

### DIFF
--- a/src/sst/core/impl/interactive/simpleDebug.cc
+++ b/src/sst/core/impl/interactive/simpleDebug.cc
@@ -44,7 +44,8 @@ SimpleDebugger::SimpleDebugger(Params& params) :
     if ( sstReplayFilePath.size() > 0 ) injectedCommand << "replay " << sstReplayFilePath << std::endl;
 
     // Populate the command registry
-    cmdRegistry = {
+    // cmdRegistry = std::vector<ConsoleCommand>({
+    cmdRegistry = CommandRegistry({
         { "help", "?", "<[CMD]>: show this help or detailed command help", ConsoleCommandGroup::GENERAL,
             [this](std::vector<std::string>& tokens) { cmd_help(tokens); } },
         { "verbose", "v", "[mask]: set verbosity mask or print if no mask specified", ConsoleCommandGroup::GENERAL,
@@ -107,10 +108,14 @@ SimpleDebugger::SimpleDebugger(Params& params) :
             [this](std::vector<std::string>& tokens) { cmd_clear(tokens); } },
         { "spinThread", "spin", "enter spin loop. See SimpleDebugger::cmd_spinThread", ConsoleCommandGroup::MISC,
             [this](std::vector<std::string>& tokens) { cmd_spinThread(tokens); } },
-    };
+        { "define", "def", "define a user command sequence", ConsoleCommandGroup::MISC,
+            [this](std::vector<std::string>& tokens) { cmd_define(tokens); } },
+        { "document", "doc", "document help for a user defined command", ConsoleCommandGroup::MISC,
+            [this](std::vector<std::string>& tokens) { cmd_document(tokens); } },
+    });
 
     // Detailed help from some commands. Can also add general things like 'help navigation'
-    cmdHelp = {
+    cmdRegistry.cmdHelp = {
         { "verbose", "[mask]: set verbosity mask or print if no mask specified\n"
                      "\tA mask is used to select which features to enable verbosity.\n"
                      "\tTo turn on all features set the mask to 0xffffffff\n"
@@ -176,16 +181,28 @@ SimpleDebugger::SimpleDebugger(Params& params) :
                      "\tctrl-d: delete character at cursor\n"
                      "\tctrl-e: move cursor to end of line\n"
                      "\tctrl-f: move cursor to the right\n" },
+        { "spinThread", ": (Deprecated) Put current thread in an infinite loop to allow\n"
+                        "an external debug to attach. The debugger can clear the spin\n"
+                        "condition and continue execution. On entry, the process id will\n"
+                        "be printed. Once in the the debugger, set the breakpoint in\n"
+                        "SimpleDebugger::cmd_spinThread (see code comments for more info)\n"
+        },
+        { "define", "<cmd-name>: enter a command sequence for a user defined command.\n"
+                    "Terminate the sequence by typing \"end\"\n"},
+        { "document","<cmd-name>: provide help documentation for a user defined command.\n"
+                    "The first line will be summarized in the short help text.\n"
+                    "Remaining lines will be provided in detailed help\n"
+                    "Terminate the sequence by typing \"end\"\n"},
     };
 
     // Command autofill strings
     std::list<std::string> cmdStrings;
-    for ( const ConsoleCommand& c : cmdRegistry ) {
+    for ( const ConsoleCommand& c : cmdRegistry.getRegistryVector() ) {
         cmdStrings.emplace_back(c.str_long());
         cmdStrings.emplace_back(c.str_short());
     }
     cmdStrings.sort();
-    cmdLineEditor.set_cmd_strings(cmdStrings); // could also realize as callback to generalize
+    cmdLineEditor.set_cmd_strings(cmdStrings);
 
     // Callback for directory listing strings
     cmdLineEditor.set_listing_callback([this](std::list<std::string>& vec) { get_listing_strings(vec); });
@@ -208,20 +225,34 @@ SimpleDebugger::execute(const std::string& msg)
     }
     done = false;
 
+    // Select the input source and next command line
     std::string line;
     while ( !done ) {
-
         try {
-            // User input prompt
-            std::cout << "> " << std::flush;
+            // User input prompt (except during user command)
+            if (eStack.size()==0)
+                std::cout << "> " << std::flush;
+            
+            // Logging disable has edge cases for stack push/pop
+            bool squashLogging = false;
 
             if ( !injectedCommand.str().empty() ) {
-                // Injected command stream (currently just one command)
+                // Injected commands allow sst command line options to cause actions (currently only replay)
                 line = injectedCommand.str();
                 injectedCommand.str("");
                 std::cout << line << std::endl;
-            }
-            else if ( replayFile.is_open() ) {
+            } else if ( eStack.size()>0) {
+                // Do no log internals of user defined command
+                squashLogging = true;
+                // Execute next instruction in a user defined command
+                line = eState.next();
+                if (eState.ret()) {
+                    eState = eStack.top();
+                    eStack.pop();
+                    // back to normal command entry
+                    if (eStack.size() == 0 ) cmdHistoryBuf.enable(true);
+                }
+            } else if ( replayFile.is_open() ) {
                 // Replay commands from file
                 if ( std::getline(replayFile, line) ) {
                     std::cout << line << std::endl;
@@ -233,8 +264,7 @@ SimpleDebugger::execute(const std::string& msg)
                         std::cout << "An error occured reading from " << replayFilePath << std::endl;
                     replayFile.close();
                 }
-            }
-            else {
+            } else {
                 // Standard Input
                 if ( !std::cin ) std::cin.clear(); // fix corrupted input after process resumed
                 std::cout.flush();
@@ -244,10 +274,11 @@ SimpleDebugger::execute(const std::string& msg)
                     std::getline(std::cin, line);
             }
 
+            // We have a constructed command line. Ship it
             dispatch_cmd(line);
 
-            // Command Logging
-            if ( enLogging ) loggingFile << line.c_str() << std::endl;
+            // Log commands if enabled and not executing a user defined command
+            if ( enLogging  && !squashLogging) loggingFile << line.c_str() << std::endl;
             // This prevents logging the 'logging' command
             if ( loggingFile.is_open() ) enLogging = true;
         }
@@ -299,18 +330,66 @@ SimpleDebugger::dispatch_cmd(std::string& cmd)
         }
     }
 
-    // Search for the requested command and execute it if found.
-    for ( auto consoleCommand : cmdRegistry ) {
-        if ( consoleCommand.match(tokens[0]) ) {
-            consoleCommand.exec(tokens); // TODO prefer having return code to know if succeeded
-            cmdHistoryBuf.append(cmd);
-            return;
+    // Check for 'end' string to terminate special line entry modes
+    if ((line_entry_mode != LINE_ENTRY_MODE::NORMAL) && (cmd == "end")) {
+        if (line_entry_mode == LINE_ENTRY_MODE::DEFINE)
+            cmdRegistry.commitUserCommand();
+        else if (line_entry_mode == LINE_ENTRY_MODE::DOCUMENT)
+            cmdRegistry.commitDocCommand();
+        else {
+            std::cout << "Error: unknown line entry mode" << std::endl;
+            assert(false);
         }
+
+        line_entry_mode = LINE_ENTRY_MODE::NORMAL;
+        std::cout << "[ returning to normal line entry mode ]" << std::endl;
+        return;
     }
 
-    // No matching command found
-    std::cout << "Unknown command: " << tokens[0].c_str() << std::endl;
-    cmdHistoryBuf.append(cmd); // want garbled command so we can fix using command line editor
+    // Do the right thing based on the entry mode
+    switch (line_entry_mode) {
+    case LINE_ENTRY_MODE::NORMAL:
+    {
+        // normal execution
+        auto consoleCommand = cmdRegistry.seek(tokens[0], CommandRegistry::SEARCH_TYPE::BUILTIN); 
+        if (consoleCommand.second) {
+            consoleCommand.first.exec(tokens);
+            cmdHistoryBuf.append(cmd);
+            return;           
+        }
+        // user defined entry
+        consoleCommand = cmdRegistry.seek(tokens[0], CommandRegistry::SEARCH_TYPE::USER); 
+        if (consoleCommand.second) {
+            cmdHistoryBuf.append(cmd);
+            // Do nothing if user command is empty
+            if (cmdRegistry.commandIsEmpty(tokens[0]))
+                return;
+            // save current context
+            eStack.push(eState);
+            // new context for user call
+            eState = { consoleCommand.first, tokens, cmdRegistry.userCommandInsts(tokens[0])};
+            // History capture disabled when stack size > 0
+            cmdHistoryBuf.enable(false);
+            return;           
+        }
+
+        // No matching command found but keep in history so we can fix it
+        std::cout << "Unknown command: " << tokens[0].c_str() << std::endl;
+        cmdHistoryBuf.append(cmd);
+        return;
+    }
+    case LINE_ENTRY_MODE::DEFINE:
+        // entering a user defined command
+        cmdRegistry.appendUserCommand(tokens[0], cmd);
+        return;
+    case LINE_ENTRY_MODE::DOCUMENT:
+        cmdRegistry.appendDocCommand(cmd);
+        return;
+    default:
+        std::cout << "ERROR: unhandled line entry mode" << std::endl;
+        assert(false);
+    } //switch (line_entry_mode)
+
 }
 
 //
@@ -343,14 +422,23 @@ SimpleDebugger::cmd_help(std::vector<std::string>& tokens)
     // First check for specific command help
     if ( tokens.size() == 1 ) {
         for ( const auto& g : GroupText ) {
-            std::cout << "--- " << g.second << " ---" << std::endl;
-            for ( const auto& c : cmdRegistry ) {
-                if ( g.first == c.group() ) std::cout << c << std::endl;
+            if (g.first != ConsoleCommandGroup::USER) {
+                std::cout << "--- " << g.second << " ---" << std::endl;
+                for ( const auto& c : cmdRegistry.getRegistryVector() ) {
+                    if ( g.first == c.group() ) std::cout << c << std::endl;
+                }
+            } else if (cmdRegistry.getUserRegistryVector().size() > 0 ) {
+                std::cout << "--- " << g.second << " ---" << std::endl;
+                for ( const auto& c : cmdRegistry.getUserRegistryVector() ) {
+                    if ( g.first == c.group() ) {
+                        std::cout << c << std::endl;
+                    }
+                }
             }
         }
-        std::cout << "\nMore detailed help also available for:\n";
+        std::cout << "\nMore detailed help available for:\n";
         std::stringstream s;
-        for ( const auto& pair : cmdHelp ) {
+        for ( const auto& pair : cmdRegistry.cmdHelp ) {
             if ( (s.str().length() + pair.first.length() > 39) ) {
                 std::cout << "\t" << s.str() << std::endl;
                 s.str("");
@@ -365,11 +453,11 @@ SimpleDebugger::cmd_help(std::vector<std::string>& tokens)
 
     if ( tokens.size() > 1 ) {
         std::string c = tokens[1];
-        if ( cmdHelp.find(c) != cmdHelp.end() ) {
-            std::cout << c << " " << cmdHelp.at(c) << std::endl;
+        if ( cmdRegistry.cmdHelp.find(c) != cmdRegistry.cmdHelp.end() ) {
+            std::cout << c << " " << cmdRegistry.cmdHelp.at(c) << std::endl;
         }
         else {
-            for ( auto& creg : cmdRegistry ) {
+            for ( auto& creg : cmdRegistry.getRegistryVector() ) {
                 if ( creg.match(c) ) std::cout << creg << std::endl;
             }
         }
@@ -1046,6 +1134,29 @@ SimpleDebugger::cmd_clear(std::vector<std::string>& UNUSED(tokens))
     std::cout << "\033[2J\033[1;1H";
 }
 
+void
+SimpleDebugger::cmd_define(std::vector<std::string>& UNUSED(tokens))
+{
+    if (tokens.size() != 2 ) {
+        std::cout << "Invalid\nsyntax: define <cmd_name>" << std::endl;
+        return;
+    }
+
+    // Create a user command entry (or clear existing one)
+    if (cmdRegistry.beginUserCommand(tokens[1])) 
+        line_entry_mode = LINE_ENTRY_MODE::DEFINE;
+}
+
+void
+SimpleDebugger::cmd_document(std::vector<std::string>& tokens) {
+    if (tokens.size() != 2 ) {
+        std::cout << "Invalid\nsyntax: document <cmd_name>" << std::endl;
+        return;
+    }
+    if (cmdRegistry.beginDocCommand(tokens[1])) 
+        line_entry_mode = LINE_ENTRY_MODE::DOCUMENT;
+}
+
 // gdb helper. Recommended SST configuration
 // CXXFLAGS="-g3 -O0" CFLAGS="-g3 -O0"  ../configure --prefix=$SST_CORE_HOME --enable-debug'
 void
@@ -1658,6 +1769,7 @@ SimpleDebugger::cmd_shutdown(std::vector<std::string>& UNUSED(tokens))
 void
 CommandHistoryBuffer::append(std::string s)
 {
+    if (! en_ ) return;
     buf_[nxt_] = std::make_pair(count_++, s);
     sz_        = sz_ < MAX_CMDS - 1 ? sz_ + 1 : MAX_CMDS;
     cur_       = nxt_;
@@ -1860,5 +1972,140 @@ SimpleDebugger::msg(VERBOSITY_MASK mask, std::string message)
     if ( (!static_cast<uint32_t>(mask)) & verbosity ) return;
     std::cout << message << std::endl;
 }
+
+std::pair<ConsoleCommand, bool> const
+CommandRegistry::seek(std::string token, SEARCH_TYPE search_type)
+{
+    last_seek_command.second = false;
+    if ( search_type == SEARCH_TYPE::ALL || search_type == SEARCH_TYPE::BUILTIN) {
+        for ( auto consoleCommand : registry ) {
+            if ( consoleCommand.match(token) ) {
+                last_seek_command.first = consoleCommand;
+                last_seek_command.second = true;
+                return last_seek_command;
+            }
+        }
+    }
+    if ( search_type == SEARCH_TYPE::ALL || search_type == SEARCH_TYPE::USER) {
+        for ( auto consoleCommand : user_registry ) {
+            if ( consoleCommand.match(token) ) {
+                last_seek_command.first = consoleCommand;
+                last_seek_command.second = true;
+                return last_seek_command;
+            }
+        }
+    }
+
+    return last_seek_command;
+}
+
+bool
+CommandRegistry::beginUserCommand(std::string name)
+{
+    // Make sure not a built-in command
+    auto res = seek(name, CommandRegistry::SEARCH_TYPE::BUILTIN);
+    if (res.second) {
+        std::cout << "Cannot overwrite built-in command \"" << name << "\"" << std::endl;
+        return false;
+    }
+    user_command_wip = name;
+    // Create or overwrite existing user defined command
+    user_defined_commands[user_command_wip] = {};
+    std::cout << "Enter commands for \"" << user_command_wip << "\" terminated by \"end\"" << std::endl;
+    return true;
+}
+
+void
+CommandRegistry::appendUserCommand(std::string token0, std::string line)
+{
+    // No recursion
+    if (token0 == user_command_wip) {
+        std::cout << token0 << " cannot call itself" << std::endl;
+        return;
+    }
+
+    // Commands not allowed: define, document, replay
+    std::pair<ConsoleCommand, bool> res = seek(token0, CommandRegistry::SEARCH_TYPE::BUILTIN);
+    if (res.second) {
+        // Disallow nested `define` or `document` since these change user_command_wip
+        if ( res.first.str_long() == "define" || res.first.str_long() == "document" ) {
+            std::cout << "Ignoring entry: " << res.first.str_long() << "/" << res.first.str_short() << std::endl;
+            return;
+        }
+        // Replay support requires changes to dispatch_cmd
+        if ( res.first.str_long() == "replay" ) {
+            std::cout << "Ignoring entry: " << res.first.str_long() << "/" << res.first.str_short() << std::endl;
+            return;
+        }
+
+    }
+    user_defined_commands[user_command_wip].emplace_back(line);
+}
+
+void
+CommandRegistry::commitUserCommand()
+{
+    std::cout << "Committing definition for " << user_command_wip << std::endl;
+    user_registry.emplace_back(ConsoleCommand(user_command_wip));
+    user_command_wip = "";
+}
+
+bool
+CommandRegistry::beginDocCommand(std::string name)
+{
+    // Make sure not a built-in command
+    auto res = seek(name, CommandRegistry::SEARCH_TYPE::BUILTIN);
+    if (res.second) {
+        std::cout << "Cannot overwrite built-in command \"" << name << "\"" << std::endl;
+        return false;
+    }
+    // Make sure user command is defined
+    res = seek(name, CommandRegistry::SEARCH_TYPE::USER);
+    if (! res.second) {
+        std::cout << "\"" << name << "\" must be defined before documenting" << std::endl;
+        return false; 
+    }
+
+    user_command_wip = name;
+    user_doc_wip = {};
+    std::cout << "Enter documentation for \"" << user_command_wip << "\" terminated by \"end\"" << std::endl;
+    return true;
+}
+
+void
+CommandRegistry::appendDocCommand(std::string line)
+{
+    user_doc_wip.emplace_back(line);
+}
+
+void
+CommandRegistry::commitDocCommand()
+{
+    bool found = false;
+    for ( ConsoleCommand& consoleCommand : user_registry ) {
+        if ( consoleCommand.match(user_command_wip) ) {
+            std::cout << "Committing documentation for " << user_command_wip << std::endl;
+            consoleCommand.setUserHelp(user_doc_wip[0]);
+            addHelp(user_command_wip,user_doc_wip);
+            found=true; 
+        }
+    }
+
+    if (! found )
+        std::cout << "Unable to commit documentation. Could not locate definition for " << user_command_wip << std::endl;
+
+    user_command_wip = "";
+    user_doc_wip = {};
+}
+
+void
+CommandRegistry::addHelp(std::string key, std::vector<std::string>& vec)
+{
+    std::stringstream s;
+    for ( const auto& line : vec )
+        s << line << "\n";
+    cmdHelp[key] = s.str();;
+}
+
 
 } // namespace SST::IMPL::Interactive

--- a/src/sst/core/impl/interactive/simpleDebug.cc
+++ b/src/sst/core/impl/interactive/simpleDebug.cc
@@ -185,14 +185,13 @@ SimpleDebugger::SimpleDebugger(Params& params) :
                         "an external debug to attach. The debugger can clear the spin\n"
                         "condition and continue execution. On entry, the process id will\n"
                         "be printed. Once in the the debugger, set the breakpoint in\n"
-                        "SimpleDebugger::cmd_spinThread (see code comments for more info)\n"
-        },
+                        "SimpleDebugger::cmd_spinThread (see code comments for more info)\n" },
         { "define", "<cmd-name>: enter a command sequence for a user defined command.\n"
-                    "Terminate the sequence by typing \"end\"\n"},
-        { "document","<cmd-name>: provide help documentation for a user defined command.\n"
-                    "The first line will be summarized in the short help text.\n"
-                    "Remaining lines will be provided in detailed help\n"
-                    "Terminate the sequence by typing \"end\"\n"},
+                    "Terminate the sequence by typing \"end\"\n" },
+        { "document", "<cmd-name>: provide help documentation for a user defined command.\n"
+                      "The first line will be summarized in the short help text.\n"
+                      "Remaining lines will be provided in detailed help\n"
+                      "Terminate the sequence by typing \"end\"\n" },
     };
 
     // Command autofill strings
@@ -230,9 +229,8 @@ SimpleDebugger::execute(const std::string& msg)
     while ( !done ) {
         try {
             // User input prompt (except during user command)
-            if (eStack.size()==0)
-                std::cout << "> " << std::flush;
-            
+            if ( eStack.size() == 0 ) std::cout << "> " << std::flush;
+
             // Logging disable has edge cases for stack push/pop
             bool squashLogging = false;
 
@@ -241,18 +239,20 @@ SimpleDebugger::execute(const std::string& msg)
                 line = injectedCommand.str();
                 injectedCommand.str("");
                 std::cout << line << std::endl;
-            } else if ( eStack.size()>0) {
+            }
+            else if ( eStack.size() > 0 ) {
                 // Do no log internals of user defined command
                 squashLogging = true;
                 // Execute next instruction in a user defined command
-                line = eState.next();
-                if (eState.ret()) {
+                line          = eState.next();
+                if ( eState.ret() ) {
                     eState = eStack.top();
                     eStack.pop();
                     // back to normal command entry
-                    if (eStack.size() == 0 ) cmdHistoryBuf.enable(true);
+                    if ( eStack.size() == 0 ) cmdHistoryBuf.enable(true);
                 }
-            } else if ( replayFile.is_open() ) {
+            }
+            else if ( replayFile.is_open() ) {
                 // Replay commands from file
                 if ( std::getline(replayFile, line) ) {
                     std::cout << line << std::endl;
@@ -264,7 +264,8 @@ SimpleDebugger::execute(const std::string& msg)
                         std::cout << "An error occured reading from " << replayFilePath << std::endl;
                     replayFile.close();
                 }
-            } else {
+            }
+            else {
                 // Standard Input
                 if ( !std::cin ) std::cin.clear(); // fix corrupted input after process resumed
                 std::cout.flush();
@@ -278,7 +279,7 @@ SimpleDebugger::execute(const std::string& msg)
             dispatch_cmd(line);
 
             // Log commands if enabled and not executing a user defined command
-            if ( enLogging  && !squashLogging) loggingFile << line.c_str() << std::endl;
+            if ( enLogging && !squashLogging ) loggingFile << line.c_str() << std::endl;
             // This prevents logging the 'logging' command
             if ( loggingFile.is_open() ) enLogging = true;
         }
@@ -331,10 +332,10 @@ SimpleDebugger::dispatch_cmd(std::string& cmd)
     }
 
     // Check for 'end' string to terminate special line entry modes
-    if ((line_entry_mode != LINE_ENTRY_MODE::NORMAL) && (cmd == "end")) {
-        if (line_entry_mode == LINE_ENTRY_MODE::DEFINE)
+    if ( (line_entry_mode != LINE_ENTRY_MODE::NORMAL) && (cmd == "end") ) {
+        if ( line_entry_mode == LINE_ENTRY_MODE::DEFINE )
             cmdRegistry.commitUserCommand();
-        else if (line_entry_mode == LINE_ENTRY_MODE::DOCUMENT)
+        else if ( line_entry_mode == LINE_ENTRY_MODE::DOCUMENT )
             cmdRegistry.commitDocCommand();
         else {
             std::cout << "Error: unknown line entry mode" << std::endl;
@@ -347,30 +348,29 @@ SimpleDebugger::dispatch_cmd(std::string& cmd)
     }
 
     // Do the right thing based on the entry mode
-    switch (line_entry_mode) {
+    switch ( line_entry_mode ) {
     case LINE_ENTRY_MODE::NORMAL:
     {
         // normal execution
-        auto consoleCommand = cmdRegistry.seek(tokens[0], CommandRegistry::SEARCH_TYPE::BUILTIN); 
-        if (consoleCommand.second) {
+        auto consoleCommand = cmdRegistry.seek(tokens[0], CommandRegistry::SEARCH_TYPE::BUILTIN);
+        if ( consoleCommand.second ) {
             consoleCommand.first.exec(tokens);
             cmdHistoryBuf.append(cmd);
-            return;           
+            return;
         }
         // user defined entry
-        consoleCommand = cmdRegistry.seek(tokens[0], CommandRegistry::SEARCH_TYPE::USER); 
-        if (consoleCommand.second) {
+        consoleCommand = cmdRegistry.seek(tokens[0], CommandRegistry::SEARCH_TYPE::USER);
+        if ( consoleCommand.second ) {
             cmdHistoryBuf.append(cmd);
             // Do nothing if user command is empty
-            if (cmdRegistry.commandIsEmpty(tokens[0]))
-                return;
+            if ( cmdRegistry.commandIsEmpty(tokens[0]) ) return;
             // save current context
             eStack.push(eState);
             // new context for user call
-            eState = { consoleCommand.first, tokens, cmdRegistry.userCommandInsts(tokens[0])};
+            eState = { consoleCommand.first, tokens, cmdRegistry.userCommandInsts(tokens[0]) };
             // History capture disabled when stack size > 0
             cmdHistoryBuf.enable(false);
-            return;           
+            return;
         }
 
         // No matching command found but keep in history so we can fix it
@@ -388,8 +388,7 @@ SimpleDebugger::dispatch_cmd(std::string& cmd)
     default:
         std::cout << "ERROR: unhandled line entry mode" << std::endl;
         assert(false);
-    } //switch (line_entry_mode)
-
+    } // switch (line_entry_mode)
 }
 
 //
@@ -422,12 +421,13 @@ SimpleDebugger::cmd_help(std::vector<std::string>& tokens)
     // First check for specific command help
     if ( tokens.size() == 1 ) {
         for ( const auto& g : GroupText ) {
-            if (g.first != ConsoleCommandGroup::USER) {
+            if ( g.first != ConsoleCommandGroup::USER ) {
                 std::cout << "--- " << g.second << " ---" << std::endl;
                 for ( const auto& c : cmdRegistry.getRegistryVector() ) {
                     if ( g.first == c.group() ) std::cout << c << std::endl;
                 }
-            } else if (cmdRegistry.getUserRegistryVector().size() > 0 ) {
+            }
+            else if ( cmdRegistry.getUserRegistryVector().size() > 0 ) {
                 std::cout << "--- " << g.second << " ---" << std::endl;
                 for ( const auto& c : cmdRegistry.getUserRegistryVector() ) {
                     if ( g.first == c.group() ) {
@@ -1137,24 +1137,23 @@ SimpleDebugger::cmd_clear(std::vector<std::string>& UNUSED(tokens))
 void
 SimpleDebugger::cmd_define(std::vector<std::string>& UNUSED(tokens))
 {
-    if (tokens.size() != 2 ) {
+    if ( tokens.size() != 2 ) {
         std::cout << "Invalid\nsyntax: define <cmd_name>" << std::endl;
         return;
     }
 
     // Create a user command entry (or clear existing one)
-    if (cmdRegistry.beginUserCommand(tokens[1])) 
-        line_entry_mode = LINE_ENTRY_MODE::DEFINE;
+    if ( cmdRegistry.beginUserCommand(tokens[1]) ) line_entry_mode = LINE_ENTRY_MODE::DEFINE;
 }
 
 void
-SimpleDebugger::cmd_document(std::vector<std::string>& tokens) {
-    if (tokens.size() != 2 ) {
+SimpleDebugger::cmd_document(std::vector<std::string>& tokens)
+{
+    if ( tokens.size() != 2 ) {
         std::cout << "Invalid\nsyntax: document <cmd_name>" << std::endl;
         return;
     }
-    if (cmdRegistry.beginDocCommand(tokens[1])) 
-        line_entry_mode = LINE_ENTRY_MODE::DOCUMENT;
+    if ( cmdRegistry.beginDocCommand(tokens[1]) ) line_entry_mode = LINE_ENTRY_MODE::DOCUMENT;
 }
 
 // gdb helper. Recommended SST configuration
@@ -1769,7 +1768,7 @@ SimpleDebugger::cmd_shutdown(std::vector<std::string>& UNUSED(tokens))
 void
 CommandHistoryBuffer::append(std::string s)
 {
-    if (! en_ ) return;
+    if ( !en_ ) return;
     buf_[nxt_] = std::make_pair(count_++, s);
     sz_        = sz_ < MAX_CMDS - 1 ? sz_ + 1 : MAX_CMDS;
     cur_       = nxt_;
@@ -1977,19 +1976,19 @@ std::pair<ConsoleCommand, bool> const
 CommandRegistry::seek(std::string token, SEARCH_TYPE search_type)
 {
     last_seek_command.second = false;
-    if ( search_type == SEARCH_TYPE::ALL || search_type == SEARCH_TYPE::BUILTIN) {
+    if ( search_type == SEARCH_TYPE::ALL || search_type == SEARCH_TYPE::BUILTIN ) {
         for ( auto consoleCommand : registry ) {
             if ( consoleCommand.match(token) ) {
-                last_seek_command.first = consoleCommand;
+                last_seek_command.first  = consoleCommand;
                 last_seek_command.second = true;
                 return last_seek_command;
             }
         }
     }
-    if ( search_type == SEARCH_TYPE::ALL || search_type == SEARCH_TYPE::USER) {
+    if ( search_type == SEARCH_TYPE::ALL || search_type == SEARCH_TYPE::USER ) {
         for ( auto consoleCommand : user_registry ) {
             if ( consoleCommand.match(token) ) {
-                last_seek_command.first = consoleCommand;
+                last_seek_command.first  = consoleCommand;
                 last_seek_command.second = true;
                 return last_seek_command;
             }
@@ -2004,11 +2003,11 @@ CommandRegistry::beginUserCommand(std::string name)
 {
     // Make sure not a built-in command
     auto res = seek(name, CommandRegistry::SEARCH_TYPE::BUILTIN);
-    if (res.second) {
+    if ( res.second ) {
         std::cout << "Cannot overwrite built-in command \"" << name << "\"" << std::endl;
         return false;
     }
-    user_command_wip = name;
+    user_command_wip                        = name;
     // Create or overwrite existing user defined command
     user_defined_commands[user_command_wip] = {};
     std::cout << "Enter commands for \"" << user_command_wip << "\" terminated by \"end\"" << std::endl;
@@ -2019,14 +2018,14 @@ void
 CommandRegistry::appendUserCommand(std::string token0, std::string line)
 {
     // No recursion
-    if (token0 == user_command_wip) {
+    if ( token0 == user_command_wip ) {
         std::cout << token0 << " cannot call itself" << std::endl;
         return;
     }
 
     // Commands not allowed: define, document, replay
     std::pair<ConsoleCommand, bool> res = seek(token0, CommandRegistry::SEARCH_TYPE::BUILTIN);
-    if (res.second) {
+    if ( res.second ) {
         // Disallow nested `define` or `document` since these change user_command_wip
         if ( res.first.str_long() == "define" || res.first.str_long() == "document" ) {
             std::cout << "Ignoring entry: " << res.first.str_long() << "/" << res.first.str_short() << std::endl;
@@ -2037,7 +2036,6 @@ CommandRegistry::appendUserCommand(std::string token0, std::string line)
             std::cout << "Ignoring entry: " << res.first.str_long() << "/" << res.first.str_short() << std::endl;
             return;
         }
-
     }
     user_defined_commands[user_command_wip].emplace_back(line);
 }
@@ -2055,19 +2053,19 @@ CommandRegistry::beginDocCommand(std::string name)
 {
     // Make sure not a built-in command
     auto res = seek(name, CommandRegistry::SEARCH_TYPE::BUILTIN);
-    if (res.second) {
+    if ( res.second ) {
         std::cout << "Cannot overwrite built-in command \"" << name << "\"" << std::endl;
         return false;
     }
     // Make sure user command is defined
     res = seek(name, CommandRegistry::SEARCH_TYPE::USER);
-    if (! res.second) {
+    if ( !res.second ) {
         std::cout << "\"" << name << "\" must be defined before documenting" << std::endl;
-        return false; 
+        return false;
     }
 
     user_command_wip = name;
-    user_doc_wip = {};
+    user_doc_wip     = {};
     std::cout << "Enter documentation for \"" << user_command_wip << "\" terminated by \"end\"" << std::endl;
     return true;
 }
@@ -2086,16 +2084,17 @@ CommandRegistry::commitDocCommand()
         if ( consoleCommand.match(user_command_wip) ) {
             std::cout << "Committing documentation for " << user_command_wip << std::endl;
             consoleCommand.setUserHelp(user_doc_wip[0]);
-            addHelp(user_command_wip,user_doc_wip);
-            found=true; 
+            addHelp(user_command_wip, user_doc_wip);
+            found = true;
         }
     }
 
-    if (! found )
-        std::cout << "Unable to commit documentation. Could not locate definition for " << user_command_wip << std::endl;
+    if ( !found )
+        std::cout << "Unable to commit documentation. Could not locate definition for " << user_command_wip
+                  << std::endl;
 
     user_command_wip = "";
-    user_doc_wip = {};
+    user_doc_wip     = {};
 }
 
 void
@@ -2104,7 +2103,8 @@ CommandRegistry::addHelp(std::string key, std::vector<std::string>& vec)
     std::stringstream s;
     for ( const auto& line : vec )
         s << line << "\n";
-    cmdHelp[key] = s.str();;
+    cmdHelp[key] = s.str();
+    ;
 }
 
 

--- a/src/sst/core/impl/interactive/simpleDebug.h
+++ b/src/sst/core/impl/interactive/simpleDebug.h
@@ -51,7 +51,7 @@ enum class VERBOSITY_MASK : uint32_t {
     WATCHPOINTS = 0b0001'0000 // 0x10
 };
 
-enum class LINE_ENTRY_MODE: int {
+enum class LINE_ENTRY_MODE : int {
     NORMAL,   // line is executed as a command
     DEFINE,   // line is captured in user defined command sequence
     DOCUMENT, // documenting a user defined command
@@ -68,21 +68,23 @@ public:
         str_short_(str_short),
         str_help_(str_help),
         group_(group),
-        func_(func) {}
-    // Constructor for user-defined commands 
+        func_(func)
+    {}
+    // Constructor for user-defined commands
     ConsoleCommand(std::string str_long) :
         str_long_(str_long),
         str_short_(str_long),
         str_help_("user defined command"),
-        group_(ConsoleCommandGroup::USER) {}
+        group_(ConsoleCommandGroup::USER)
+    {}
     ConsoleCommand() {}; // default constructor
-    const std::string&         str_long() const { return str_long_; }
-    const std::string&         str_short() const { return str_short_; }
-    const std::string&         str_help() const { return str_help_; }
-    void setUserHelp(std::string& help) {  str_help_ = help; }
+    const std::string& str_long() const { return str_long_; }
+    const std::string& str_short() const { return str_short_; }
+    const std::string& str_help() const { return str_help_; }
+    void               setUserHelp(std::string& help) { str_help_ = help; }
 
     // Command Execution
-    void                       exec(std::vector<std::string>& tokens) { return func_(tokens); }
+    void exec(std::vector<std::string>& tokens) { return func_(tokens); }
 
     const ConsoleCommandGroup& group() const { return group_; }
     bool                       match(const std::string& token)
@@ -109,8 +111,8 @@ private:
         std::transform(s.begin(), s.end(), s.begin(), ::tolower);
         return s;
     }
-    
-}; //class ConsoleCommand
+
+}; // class ConsoleCommand
 
 class CommandHistoryBuffer
 {
@@ -122,7 +124,7 @@ public:
     std::vector<std::string>& getBuffer();
     enum BANG_RC { INVALID, ECHO_ONLY, EXEC, NOP };
     BANG_RC bang(const std::string& token, std::string& newcmd);
-    void enable(bool en) { en_ = en; }
+    void    enable(bool en) { en_ = en; }
 
 private:
     bool                                             en_    = true;
@@ -139,83 +141,93 @@ private:
     bool                     searchAny(const std::string& s, std::string& newcmd);
 };
 
-class CommandRegistry {
+class CommandRegistry
+{
 
-    public:
+public:
     // Construction
     CommandRegistry() {}
-    CommandRegistry(const std::vector<ConsoleCommand> in) : registry(in) {}
+    CommandRegistry(const std::vector<ConsoleCommand> in) :
+        registry(in)
+    {}
     // Access
     std::vector<ConsoleCommand>& getRegistryVector() { return registry; }
     std::vector<ConsoleCommand>& getUserRegistryVector() { return user_registry; }
     enum SEARCH_TYPE { ALL, BUILTIN, USER };
     std::pair<ConsoleCommand, bool> const seek(std::string token, SEARCH_TYPE search_type);
     // User defined command entry
-    bool beginUserCommand(std::string name);
-    void appendUserCommand(std::string token0, std::string line);
-    void commitUserCommand();
-    std::vector<std::string>* userCommandInsts(std::string key) {
-        if (user_defined_commands.find(key) == user_defined_commands.end())
-            return nullptr;
+    bool                                  beginUserCommand(std::string name);
+    void                                  appendUserCommand(std::string token0, std::string line);
+    void                                  commitUserCommand();
+    std::vector<std::string>*             userCommandInsts(std::string key)
+    {
+        if ( user_defined_commands.find(key) == user_defined_commands.end() ) return nullptr;
         return &user_defined_commands[key];
     }
     // User defined command help doc entry
     bool beginDocCommand(std::string name);
     void appendDocCommand(std::string line);
     void commitDocCommand();
-    bool commandIsEmpty(const std::string key) {
-        if (user_defined_commands.find(key) == user_defined_commands.end())
-            return true;
-        if (user_defined_commands[key].size() == 0) return true;
+    bool commandIsEmpty(const std::string key)
+    {
+        if ( user_defined_commands.find(key) == user_defined_commands.end() ) return true;
+        if ( user_defined_commands[key].size() == 0 ) return true;
         return false;
-    }; 
+    };
 
     // User defined command help from vector
-    void addHelp(std::string key, std::vector<std::string>& vec);
+    void                               addHelp(std::string key, std::vector<std::string>& vec);
     // Detailed Command Help (public for now)
     std::map<std::string, std::string> cmdHelp;
 
 private:
     // built-in commands
-    std::vector<ConsoleCommand> registry = {};
+    std::vector<ConsoleCommand>                     registry              = {};
     // user defined commands
-    std::vector<ConsoleCommand> user_registry = {};
+    std::vector<ConsoleCommand>                     user_registry         = {};
     std::map<std::string, std::vector<std::string>> user_defined_commands = {};
-    std::string user_command_wip = "";
-    std::vector<std::string> user_doc_wip = {};
+    std::string                                     user_command_wip      = "";
+    std::vector<std::string>                        user_doc_wip          = {};
 
-    // Last searched command with valid indicator 
-    std::pair<ConsoleCommand, bool> last_seek_command = {}; 
-};// class CommandRegistry
+    // Last searched command with valid indicator
+    std::pair<ConsoleCommand, bool> last_seek_command = {};
+}; // class CommandRegistry
 
 // Support for nesting user defined commands
-class ExecState {
+class ExecState
+{
 public:
     // Constructor for entering a new user command
-    ExecState(ConsoleCommand cmd, std::vector<std::string> tokens, std::vector<std::string>* insts)
-        : cmd_(cmd), tokens_(tokens), insts_(insts), index_(0), user_(true) {
-            assert(insts_->size()>0);
-        };
+    ExecState(ConsoleCommand cmd, std::vector<std::string> tokens, std::vector<std::string>* insts) :
+        cmd_(cmd),
+        tokens_(tokens),
+        insts_(insts),
+        index_(0),
+        user_(true)
+    {
+        assert(insts_->size() > 0);
+    };
     ExecState() {};
-    bool ret() { return ret_; }
+    bool        ret() { return ret_; }
     // Advance state and return the next user instruction
-    std::string next() {
+    std::string next()
+    {
         assert(user_);
         assert(!ret_);
         assert(insts_);
-        assert(index_<insts_->size());
-        ret_ =  (index_+1) == insts_->size();
+        assert(index_ < insts_->size());
+        ret_ = (index_ + 1) == insts_->size();
         return insts_->at(index_++);
     }
 
 private:
-    ConsoleCommand cmd_ = {};                    // user command in progress
-    std::vector<std::string> tokens_ = {};       // command args
-    std::vector<std::string>* insts_ = nullptr;  // command sequence
-    size_t index_ = 0;                           // command pointer
-    bool user_ = false;                          // in user command
-    bool ret_ = false;                           // user command complete, return to caller
-}; //class ExecState
+    ConsoleCommand            cmd_    = {};      // user command in progress
+    std::vector<std::string>  tokens_ = {};      // command args
+    std::vector<std::string>* insts_  = nullptr; // command sequence
+    size_t                    index_  = 0;       // command pointer
+    bool                      user_   = false;   // in user command
+    bool                      ret_    = false;   // user command complete, return to caller
+}; // class ExecState
 
 class SimpleDebugger : public SST::InteractiveConsole
 {
@@ -270,7 +282,7 @@ private:
     std::stringstream injectedCommand;
 
     // execution state management for nested user commands
-    ExecState eState = {};
+    ExecState             eState = {};
     std::stack<ExecState> eStack = {};
 
     // Keep a pointer to the ObjectMap for the top level Component
@@ -343,7 +355,7 @@ private:
     CommandHistoryBuffer cmdHistoryBuf;
 
     // Command Line Editor
-    CmdLineEditor cmdLineEditor;
+    CmdLineEditor   cmdLineEditor;
     LINE_ENTRY_MODE line_entry_mode = LINE_ENTRY_MODE::NORMAL;
 
     // Verbosity controlled console printing

--- a/src/sst/core/impl/interactive/simpleDebug.h
+++ b/src/sst/core/impl/interactive/simpleDebug.h
@@ -17,6 +17,7 @@
 #include <cstdint>
 #include <ostream>
 #include <sstream>
+#include <stack>
 #include <sst/core/interactiveConsole.h>
 #include "sst/core/serialization/objectMapDeferred.h"
 #include "sst/core/impl/interactive/cmdLineEditor.h"
@@ -31,7 +32,7 @@
 
 namespace SST::IMPL::Interactive {
 
-enum class ConsoleCommandGroup { GENERAL, NAVIGATION, STATE, WATCH, SIMULATION, LOGGING, MISC };
+enum class ConsoleCommandGroup { GENERAL, NAVIGATION, STATE, WATCH, SIMULATION, LOGGING, MISC, USER };
 
 const std::map<ConsoleCommandGroup, std::string> GroupText {
     { ConsoleCommandGroup::GENERAL, "General" },
@@ -41,35 +42,54 @@ const std::map<ConsoleCommandGroup, std::string> GroupText {
     { ConsoleCommandGroup::SIMULATION, "Simulation" },
     { ConsoleCommandGroup::LOGGING, "Logging" },
     { ConsoleCommandGroup::MISC, "Misc" },
+    { ConsoleCommandGroup::USER, "User Defined" },
 };
 
+// Each bit of mask enables verbosity for different debug features.
+// This is primarily for developers.
 enum class VERBOSITY_MASK : uint32_t {
     WATCHPOINTS = 0b0001'0000 // 0x10
+};
+
+enum class LINE_ENTRY_MODE: int {
+    NORMAL,   // line is executed as a command
+    DEFINE,   // line is captured in user defined command sequence
+    DOCUMENT, // documenting a user defined command
 };
 
 // Encapsulate a console command.
 class ConsoleCommand
 {
 public:
+    // Constructor for built-in commands has callback
     ConsoleCommand(std::string str_long, std::string str_short, std::string str_help, ConsoleCommandGroup group,
         std::function<void(std::vector<std::string>& tokens)> func) :
         str_long_(str_long),
         str_short_(str_short),
         str_help_(str_help),
         group_(group),
-        func_(func)
-    {}
+        func_(func) {}
+    // Constructor for user-defined commands 
+    ConsoleCommand(std::string str_long) :
+        str_long_(str_long),
+        str_short_(str_long),
+        str_help_("user defined command"),
+        group_(ConsoleCommandGroup::USER) {}
+    ConsoleCommand() {}; // default constructor
     const std::string&         str_long() const { return str_long_; }
     const std::string&         str_short() const { return str_short_; }
     const std::string&         str_help() const { return str_help_; }
-    const ConsoleCommandGroup& group() const { return group_; }
+    void setUserHelp(std::string& help) {  str_help_ = help; }
+
+    // Command Execution
     void                       exec(std::vector<std::string>& tokens) { return func_(tokens); }
+
+    const ConsoleCommandGroup& group() const { return group_; }
     bool                       match(const std::string& token)
     {
         std::string lctoken = toLower(token);
         if ( lctoken.size() == str_long_.size() && lctoken == toLower(str_long_) ) return true;
         if ( lctoken.size() == str_short_.size() && lctoken == toLower(str_short_) ) return true;
-
         return false;
     }
     friend std::ostream& operator<<(std::ostream& os, const ConsoleCommand c)
@@ -83,13 +103,14 @@ private:
     std::string                                           str_short_;
     std::string                                           str_help_;
     ConsoleCommandGroup                                   group_;
-    std::function<void(std::vector<std::string>& tokens)> func_;
+    std::function<void(std::vector<std::string>& tokens)> func_ = {};
     std::string                                           toLower(std::string s)
     {
         std::transform(s.begin(), s.end(), s.begin(), ::tolower);
         return s;
     }
-};
+    
+}; //class ConsoleCommand
 
 class CommandHistoryBuffer
 {
@@ -101,8 +122,10 @@ public:
     std::vector<std::string>& getBuffer();
     enum BANG_RC { INVALID, ECHO_ONLY, EXEC, NOP };
     BANG_RC bang(const std::string& token, std::string& newcmd);
+    void enable(bool en) { en_ = en; }
 
 private:
+    bool                                             en_    = true;
     int                                              cur_   = 0;
     int                                              nxt_   = 0;
     int                                              sz_    = 0;
@@ -115,6 +138,84 @@ private:
     bool                     searchFirst(const std::string& s, std::string& newcmd);
     bool                     searchAny(const std::string& s, std::string& newcmd);
 };
+
+class CommandRegistry {
+
+    public:
+    // Construction
+    CommandRegistry() {}
+    CommandRegistry(const std::vector<ConsoleCommand> in) : registry(in) {}
+    // Access
+    std::vector<ConsoleCommand>& getRegistryVector() { return registry; }
+    std::vector<ConsoleCommand>& getUserRegistryVector() { return user_registry; }
+    enum SEARCH_TYPE { ALL, BUILTIN, USER };
+    std::pair<ConsoleCommand, bool> const seek(std::string token, SEARCH_TYPE search_type);
+    // User defined command entry
+    bool beginUserCommand(std::string name);
+    void appendUserCommand(std::string token0, std::string line);
+    void commitUserCommand();
+    std::vector<std::string>* userCommandInsts(std::string key) {
+        if (user_defined_commands.find(key) == user_defined_commands.end())
+            return nullptr;
+        return &user_defined_commands[key];
+    }
+    // User defined command help doc entry
+    bool beginDocCommand(std::string name);
+    void appendDocCommand(std::string line);
+    void commitDocCommand();
+    bool commandIsEmpty(const std::string key) {
+        if (user_defined_commands.find(key) == user_defined_commands.end())
+            return true;
+        if (user_defined_commands[key].size() == 0) return true;
+        return false;
+    }; 
+
+    // User defined command help from vector
+    void addHelp(std::string key, std::vector<std::string>& vec);
+    // Detailed Command Help (public for now)
+    std::map<std::string, std::string> cmdHelp;
+
+private:
+    // built-in commands
+    std::vector<ConsoleCommand> registry = {};
+    // user defined commands
+    std::vector<ConsoleCommand> user_registry = {};
+    std::map<std::string, std::vector<std::string>> user_defined_commands = {};
+    std::string user_command_wip = "";
+    std::vector<std::string> user_doc_wip = {};
+
+    // Last searched command with valid indicator 
+    std::pair<ConsoleCommand, bool> last_seek_command = {}; 
+};// class CommandRegistry
+
+// Support for nesting user defined commands
+class ExecState {
+public:
+    // Constructor for entering a new user command
+    ExecState(ConsoleCommand cmd, std::vector<std::string> tokens, std::vector<std::string>* insts)
+        : cmd_(cmd), tokens_(tokens), insts_(insts), index_(0), user_(true) {
+            assert(insts_->size()>0);
+        };
+    ExecState() {};
+    bool ret() { return ret_; }
+    // Advance state and return the next user instruction
+    std::string next() {
+        assert(user_);
+        assert(!ret_);
+        assert(insts_);
+        assert(index_<insts_->size());
+        ret_ =  (index_+1) == insts_->size();
+        return insts_->at(index_++);
+    }
+
+private:
+    ConsoleCommand cmd_ = {};                    // user command in progress
+    std::vector<std::string> tokens_ = {};       // command args
+    std::vector<std::string>* insts_ = nullptr;  // command sequence
+    size_t index_ = 0;                           // command pointer
+    bool user_ = false;                          // in user command
+    bool ret_ = false;                           // user command complete, return to caller
+}; //class ExecState
 
 class SimpleDebugger : public SST::InteractiveConsole
 {
@@ -165,8 +266,12 @@ private:
     std::string   replayFilePath  = "sst-console.in";
     bool          enLogging       = false;
 
-    // command injection
-    std::stringstream injectedCommand; // TODO use ConsoleCommand object
+    // command injection (for sst --replay option)
+    std::stringstream injectedCommand;
+
+    // execution state management for nested user commands
+    ExecState eState = {};
+    std::stack<ExecState> eStack = {};
 
     // Keep a pointer to the ObjectMap for the top level Component
     SST::Core::Serialization::ObjectMapDeferred<BaseComponent>* base_comp_ = nullptr;
@@ -221,22 +326,25 @@ private:
     // Reset terminal
     void cmd_clear(std::vector<std::string>& UNUSED(tokens));
 
+    // User defined commands
+    void cmd_define(std::vector<std::string>& tokens);
+    void cmd_document(std::vector<std::string>& tokens);
+
     // LLDB/GDB helper
     void cmd_spinThread(std::vector<std::string>& tokens);
 
+    // command entry point
     void dispatch_cmd(std::string& cmd);
 
     // Command Registry
-    std::vector<ConsoleCommand> cmdRegistry;
-
-    // Detailed Command Help
-    std::map<std::string, std::string> cmdHelp;
+    CommandRegistry cmdRegistry;
 
     // Command History
     CommandHistoryBuffer cmdHistoryBuf;
 
     // Command Line Editor
     CmdLineEditor cmdLineEditor;
+    LINE_ENTRY_MODE line_entry_mode = LINE_ENTRY_MODE::NORMAL;
 
     // Verbosity controlled console printing
     uint32_t verbosity = 0;


### PR DESCRIPTION
This is a major feature PR to support user defined command sequences inspired from gdb.
Unlimited nesting of user commands is supported.

Usage
```
Entering interactive mode at time 0 
Interactive start at 0
> help define
define <cmd-name>: enter a command sequence for a user defined command.
Terminate the sequence by typing "end"

> help document
document <cmd-name>: provide help documentation for a user defined command.
The first line will be summarized in the short help text.
Remaining lines will be provided in detailed help
Terminate the sequence by typing "end"

> define pair_0
Enter commands for "pair_0" terminated by "end"
> cd cp0
> cd v_pair_u64_str/
> p 0
> cd ..
> cd ..
> end
Committing definition for pair_0
[ returning to normal line entry mode ]

> pair_0
0 = 42 (unsigned long long)

> doc pair_0
Enter documentation for "pair_0" terminated by "end"
> First line of pair_0 doc string
> Second line of pair_0 doc string
> end
Committing documentation for pair_0
[ returning to normal line entry mode ]

> help 
--- General ---
help (?) <[CMD]>: show this help or detailed command help
verbose (v) [mask]: set verbosity mask or print if no mask specified
confirm (cfm) <true/false>: set confirmation requests on (default) or off
--- Navigation ---
... omitted
--- User Defined ---
pair_0 (pair_0) First line of pair_0 doc string

More detailed help available for:
        addtracevar define document editing 
        examine history pair_0 print printtrace 
        printwatchpoint resettrace run set 
        sethandler spinThread trace unwatch 

> help pair_0
pair_0 First line of pair_0 doc string
Second line of pair_0 doc string


```
Upcoming PRs
- Move Classes into separate files to reduce size of the simple debugger source code file.
- Support for  using arguments passed to the command
- Command auto-completion working with user defined commands 
- `show` command to list definition 

Testing Notes:
New test added to sst-ext-tests/userdef ( see tests/core-debug/cmd-define.sh ).
(https://github.com/tactcomplabs/sst-ext-tests/pull/55)


