### PR TITLE
Single-rank, multithreaded interactive debug console support

### DIFF
--- a/src/sst/core/impl/interactive/simpleDebug.cc
+++ b/src/sst/core/impl/interactive/simpleDebug.cc
@@ -275,7 +275,7 @@ SimpleDebugger::execute(const std::string& msg)
             bool squashLogging = false;
 
             // User input prompt
-            std::cout << "R" << info.rank << ":T" << info.thread << "> " << std::flush;
+            // std::cout << "R" << info.rank << ":T" << info.thread << "> " << std::flush;
 
             if ( !injectedCommand.str().empty() ) {
                 // Injected commands allow sst command line options to cause actions (currently only replay)

--- a/src/sst/core/impl/interactive/simpleDebug.cc
+++ b/src/sst/core/impl/interactive/simpleDebug.cc
@@ -46,6 +46,10 @@ SimpleDebugger::SimpleDebugger(Params& params) :
             [this](std::vector<std::string>& tokens) { cmd_help(tokens); } },
         { "verbose", "v", "[mask]: set verbosity mask or print if no mask specified", ConsoleCommandGroup::GENERAL,
             [this](std::vector<std::string>& tokens) { cmd_verbose(tokens); } },
+        { "info", "info", "\"current\"|\"all\" print summary for current thread or all threads", ConsoleCommandGroup::GENERAL,
+            [this](std::vector<std::string>& tokens) { cmd_info(tokens); } },
+        { "thread", "thd", "[threadID]: switch to specified thread ID", ConsoleCommandGroup::GENERAL,
+            [this](std::vector<std::string>& tokens) { cmd_thread(tokens); } },
         { "confirm", "cfm", "<true/false>: set confirmation requests on (default) or off", ConsoleCommandGroup::GENERAL,
             [this](std::vector<std::string>& tokens) { cmd_setConfirm(tokens); } },
         { "pwd", "pwd", "print the current working directory in the object map", ConsoleCommandGroup::NAVIGATION,
@@ -212,15 +216,52 @@ SimpleDebugger::~SimpleDebugger()
 }
 
 void
+SimpleDebugger::summary()
+{
+#if 0
+    RankInfo info = getRank();
+    RankInfo nRanks = getNumRanks();
+    std::count << "\n(Rank:" << info.rank << " / " << nRanks.rank
+        << " Thread:" << info.thread << "/" << nRanks.thread
+        << ")\n";
+    std::cout << " -- Trigger Status\n";
+#endif
+    
+    std::cout << " -- Component Summary\n";
+#if 0
+    std::vector<std::string> tokens;
+    if (nullptr == obj_) {
+        obj_ = getComponentObjectMap();
+    }
+    cmd_ls(tokens);
+#else
+    SST::Core::Serialization::ObjectMap* baseObj = getComponentObjectMap();
+    auto& vars = baseObj->getVariables();
+    for (auto& x : vars) {
+        if (x.second->isFundamental()) {
+            std::cout << x.first << " = " << x.second->get() << " (" << x.second->getType() << ")" << std::endl;
+        }
+        else {
+            std::cout << x.first.c_str() << "/ (" << x.second->getType() << ")\n";
+        }
+    }
+#endif
+}
+
+int
 SimpleDebugger::execute(const std::string& msg)
 {
-    printf("Entering interactive mode at time %" PRI_SIMTIME " \n", getCurrentSimCycle());
+    RankInfo info = getRank();
+    RankInfo nRanks = getNumRanks();
+    printf("\n---- Rank%d:Thread%d: Entering interactive mode at time %" PRI_SIMTIME " \n", info.rank, info.thread, getCurrentSimCycle());
     printf("%s\n", msg.c_str());
 
     if ( nullptr == obj_ ) {
         obj_ = getComponentObjectMap();
     }
     done = false;
+    retState = -1;
+    
 
     // Select the input source and next command line
     std::string line;
@@ -231,6 +272,9 @@ SimpleDebugger::execute(const std::string& msg)
 
             // Logging disable has edge cases for stack push/pop
             bool squashLogging = false;
+
+            // User input prompt
+            std::cout << "R" << info.rank << ":T" << info.thread << "> " << std::flush;
 
             if ( !injectedCommand.str().empty() ) {
                 // Injected commands allow sst command line options to cause actions (currently only replay)
@@ -285,6 +329,7 @@ SimpleDebugger::execute(const std::string& msg)
             std::cout << "Parsing error. Ignoring " << line << std::endl;
         }
     }
+    return retState;
 }
 
 // Invoke the command.
@@ -486,6 +531,78 @@ SimpleDebugger::cmd_verbose(std::vector<std::string>& tokens)
     }
 }
 
+void
+SimpleDebugger::cmd_info(std::vector<std::string>& UNUSED(tokens)) {
+
+    if (tokens.size() != 2) {
+        printf("Invalid format for info command (info \"current\"|\"all\")\n");
+        return;
+    }
+
+    RankInfo info = getRank();
+    RankInfo nRanks = getNumRanks();
+    if (tokens[1] == "current") {
+        std::cout << "Rank " << info.rank << "/" << nRanks.rank
+            << ", Thread " << info.thread << "/" << nRanks.thread << std::endl;
+    }
+    else if (tokens[1] == "all") {
+        if (nRanks.rank == 1 && nRanks.thread == 1) {
+            std::cout << "Rank " << info.rank << "/" << nRanks.rank
+                << ", Thread " << info.thread << "/" << nRanks.thread << std::endl;
+        }
+        else {
+            // Return to syncmanager to print summary for all threads
+            retState = -2; // summary info
+            done = true;
+        }
+    }
+    else {
+        printf("Invalid argument for info command: %s (info \"current\"|\"all\")\n", tokens[1].c_str());
+        return;
+    }
+}
+
+// thread <threadID> : switches to new thread
+void
+SimpleDebugger::cmd_thread(std::vector<std::string>& tokens) {
+
+    if (tokens.size() != 2) {
+        printf("Invalid format for thread command (thread <threadID>)\n");
+        return;
+    }
+
+    RankInfo info = getRank();
+    RankInfo nRanks = getNumRanks();
+    int threadID;
+
+    // Get threadID
+    try {
+        threadID = std::stoi(tokens[1]);
+    }
+    catch (const std::invalid_argument& e) {
+        std::cout << "Invalid argument for threadID: " << tokens[1] << std::endl;
+        return;
+    }
+    catch (const std::out_of_range& e) {
+        std::cout << "Out of range for threadID: " << tokens[1] << std::endl;
+        return;
+    }
+
+    // Check if valid threadID
+    if (threadID < 0 || threadID >= nRanks.thread) {
+        printf("ThreadID %d out of range (0:%d)\n", threadID, nRanks.thread-1);
+        return;
+    }
+    
+    // If not current thread, set retState and done flag
+    if (threadID != info.thread) {
+        retState = threadID;
+        done = true;
+    }
+    return;
+}
+
+
 // pwd: print current working directory
 void
 SimpleDebugger::cmd_pwd(std::vector<std::string>& UNUSED(tokens))
@@ -537,10 +654,18 @@ SimpleDebugger::get_listing_strings(std::list<std::string>& list)
 void
 SimpleDebugger::cmd_cd(std::vector<std::string>& tokens)
 {
+#if 1
     if ( tokens.size() != 2 ) {
         printf("Invalid format for cd command (cd <obj>)\n");
         return;
     }
+#else
+    // skk This works but doesn't delete/deactivate like objmap selectParent
+    if (tokens.size() == 1) {
+        obj_ = getComponentObjectMap();
+        return;
+    }
+#endif
 
     // Allow for trailing '/'
     std::string selection = tokens[1];

--- a/src/sst/core/impl/interactive/simpleDebug.cc
+++ b/src/sst/core/impl/interactive/simpleDebug.cc
@@ -133,7 +133,9 @@ SimpleDebugger::SimpleDebugger(Params& params) :
             "\t'watch' creates a default watchpoint that breaks into an interactive console when triggered\n"
             "\t'trace' creates a watchpoint with a trace buffer to trace a set of variables and trigger an <action>\n"
             "\tAvailable actions include: \n"
-            "\t  interactive, printTrace, checkpoint, set <var> <val>, printStatus, or shutdown" },
+            "\t  interactive, printTrace, checkpoint, set <var> <val>, printStatus, or shutdown" 
+            "\t  Note: checkpoint action must be enabled at startup via the '--checkpoint-enable' command line option\n"
+},
         { "watch", "<trigger>: adds watchpoint to the watchlist; breaks into interactive console when triggered\n"
                    "\tExample: watch var1 > 90 && var2 < 100 || var3 changed" },
         { "trace",
@@ -791,6 +793,22 @@ SimpleDebugger::cmd_run(std::vector<std::string>& tokens)
             printf("Unknown time in call to run: %s\n", tokens[1].c_str());
             return;
         }
+    }
+    else if (tokens.size() == 3) {
+        std::string time = tokens[1] + tokens[2];
+        try {
+            TimeConverter* tc = getTimeConverter(time);
+            std::string    msg = format_string("Running clock %" PRI_SIMTIME " sim cycles", tc->getFactor());
+            schedule_interactive(tc->getFactor(), msg);
+        }
+        catch (std::exception& e) {
+            printf("Unknown time in call to run: %s\n", time.c_str());
+            return;
+        }
+
+    }
+    else if (tokens.size() != 1) {
+        printf("Too many arguments for 'run <time>'\n");
     }
 
     done = true;

--- a/src/sst/core/impl/interactive/simpleDebug.cc
+++ b/src/sst/core/impl/interactive/simpleDebug.cc
@@ -739,29 +739,23 @@ SimpleDebugger::cmd_print(std::vector<std::string>& tokens)
     // See if have a -r or not
     int         recurse = 0;
     std::string tok     = tokens[1];
-    if ( tok.size() >= 2 && tok[0] == '-' && tok[1] == 'r' ) {
+    if ( (tok.size() >= 2) && (tok[0] == '-') && (tok[1] == 'r') ) {
         // Got a -r
-        std::string num = tok.substr(2);
-        if ( num.size() != 0 ) {
-            try {
-                recurse = SST::Core::from_string<int>(num);
-            }
-            catch ( const std::invalid_argument& e ) {
-                printf("Invalid number format specified with -r: %s\n", tok.c_str());
-                return;
+        if (tok.size() == 2) {
+            recurse = 4;
+        } else {
+            std::string num = tok.substr(2);
+            if (num.size() != 0) {
+                try {
+                    recurse = SST::Core::from_string<int>(num);
+                }
+                catch (std::invalid_argument& e) {
+                    printf("Invalid number format specified with -r: %s\n", tok.c_str());
+                    return;
+                }
             }
         }
-        else {
-            recurse = 4; // default -r depth
-        }
-
         var_index = 2;
-    }
-
-    if ( tokens.size() == var_index ) {
-        // Print current object
-        obj_->list(recurse);
-        return;
     }
 
     if ( tokens.size() != (var_index + 1) ) {
@@ -771,9 +765,8 @@ SimpleDebugger::cmd_print(std::vector<std::string>& tokens)
 
     bool        found;
     std::string listing = obj_->listVariable(tokens[var_index], found, recurse);
-
     if ( !found ) {
-        printf("Unknown object in print command: %s\n", tokens[1].c_str());
+        printf("Unknown object in print command: %s\n", tokens[var_index].c_str());
         return;
     }
     else {

--- a/src/sst/core/impl/interactive/simpleDebug.cc
+++ b/src/sst/core/impl/interactive/simpleDebug.cc
@@ -544,13 +544,17 @@ SimpleDebugger::cmd_info(std::vector<std::string>& UNUSED(tokens))
     RankInfo info   = getRank();
     RankInfo nRanks = getNumRanks();
     if ( tokens[1] == "current" ) {
-        std::cout << "Rank " << info.rank << "/" << nRanks.rank << ", Thread " << info.thread << "/" << nRanks.thread
-                  << std::endl;
+        std::cout << "Rank " << info.rank << "/" << nRanks.rank 
+            << ", Thread " << info.thread << "/" << nRanks.thread
+            << " (Process " << getppid() << ")"
+            << std::endl;
     }
     else if ( tokens[1] == "all" ) {
         if ( nRanks.rank == 1 && nRanks.thread == 1 ) {
-            std::cout << "Rank " << info.rank << "/" << nRanks.rank << ", Thread " << info.thread << "/"
-                      << nRanks.thread << std::endl;
+            std::cout << "Rank " << info.rank << "/" << nRanks.rank 
+                << ", Thread " << info.thread << "/"<< nRanks.thread
+                << " (Process " << getppid() << ")"
+                << std::endl;
         }
         else {
             // Return to syncmanager to print summary for all threads

--- a/src/sst/core/impl/interactive/simpleDebug.cc
+++ b/src/sst/core/impl/interactive/simpleDebug.cc
@@ -261,7 +261,7 @@ SimpleDebugger::execute(const std::string& msg)
         obj_ = getComponentObjectMap();
     }
     done     = false;
-    retState = -1;
+    retState = DONE;
 
 
     // Select the input source and next command line
@@ -554,7 +554,7 @@ SimpleDebugger::cmd_info(std::vector<std::string>& UNUSED(tokens))
         }
         else {
             // Return to syncmanager to print summary for all threads
-            retState = -2; // summary info
+            retState = SUMMARY; // summary info
             done     = true;
         }
     }
@@ -592,13 +592,13 @@ SimpleDebugger::cmd_thread(std::vector<std::string>& tokens)
     }
 
     // Check if valid threadID
-    if ( threadID < 0 || threadID >= nRanks.thread ) {
+    if ( threadID < 0 || threadID >= static_cast<int>(nRanks.thread) ) {
         printf("ThreadID %d out of range (0:%d)\n", threadID, nRanks.thread - 1);
         return;
     }
 
     // If not current thread, set retState and done flag
-    if ( threadID != info.thread ) {
+    if ( threadID != static_cast<int>(info.thread) ) {
         retState = threadID;
         done     = true;
     }

--- a/src/sst/core/impl/interactive/simpleDebug.cc
+++ b/src/sst/core/impl/interactive/simpleDebug.cc
@@ -46,8 +46,8 @@ SimpleDebugger::SimpleDebugger(Params& params) :
             [this](std::vector<std::string>& tokens) { cmd_help(tokens); } },
         { "verbose", "v", "[mask]: set verbosity mask or print if no mask specified", ConsoleCommandGroup::GENERAL,
             [this](std::vector<std::string>& tokens) { cmd_verbose(tokens); } },
-        { "info", "info", "\"current\"|\"all\" print summary for current thread or all threads", ConsoleCommandGroup::GENERAL,
-            [this](std::vector<std::string>& tokens) { cmd_info(tokens); } },
+        { "info", "info", "\"current\"|\"all\" print summary for current thread or all threads",
+            ConsoleCommandGroup::GENERAL, [this](std::vector<std::string>& tokens) { cmd_info(tokens); } },
         { "thread", "thd", "[threadID]: switch to specified thread ID", ConsoleCommandGroup::GENERAL,
             [this](std::vector<std::string>& tokens) { cmd_thread(tokens); } },
         { "confirm", "cfm", "<true/false>: set confirmation requests on (default) or off", ConsoleCommandGroup::GENERAL,
@@ -137,9 +137,9 @@ SimpleDebugger::SimpleDebugger(Params& params) :
             "\t'watch' creates a default watchpoint that breaks into an interactive console when triggered\n"
             "\t'trace' creates a watchpoint with a trace buffer to trace a set of variables and trigger an <action>\n"
             "\tAvailable actions include: \n"
-            "\t  interactive, printTrace, checkpoint, set <var> <val>, printStatus, or shutdown" 
-            "\t  Note: checkpoint action must be enabled at startup via the '--checkpoint-enable' command line option\n"
-},
+            "\t  interactive, printTrace, checkpoint, set <var> <val>, printStatus, or shutdown"
+            "\t  Note: checkpoint action must be enabled at startup via the '--checkpoint-enable' command line "
+            "option\n" },
         { "watch", "<trigger>: adds watchpoint to the watchlist; breaks into interactive console when triggered\n"
                    "\tExample: watch var1 > 90 && var2 < 100 || var3 changed" },
         { "trace",
@@ -226,7 +226,7 @@ SimpleDebugger::summary()
         << ")\n";
     std::cout << " -- Trigger Status\n";
 #endif
-    
+
     std::cout << " -- Component Summary\n";
 #if 0
     std::vector<std::string> tokens;
@@ -236,9 +236,9 @@ SimpleDebugger::summary()
     cmd_ls(tokens);
 #else
     SST::Core::Serialization::ObjectMap* baseObj = getComponentObjectMap();
-    auto& vars = baseObj->getVariables();
-    for (auto& x : vars) {
-        if (x.second->isFundamental()) {
+    auto&                                vars    = baseObj->getVariables();
+    for ( auto& x : vars ) {
+        if ( x.second->isFundamental() ) {
             std::cout << x.first << " = " << x.second->get() << " (" << x.second->getType() << ")" << std::endl;
         }
         else {
@@ -251,17 +251,18 @@ SimpleDebugger::summary()
 int
 SimpleDebugger::execute(const std::string& msg)
 {
-    RankInfo info = getRank();
+    RankInfo info   = getRank();
     RankInfo nRanks = getNumRanks();
-    printf("\n---- Rank%d:Thread%d: Entering interactive mode at time %" PRI_SIMTIME " \n", info.rank, info.thread, getCurrentSimCycle());
+    printf("\n---- Rank%d:Thread%d: Entering interactive mode at time %" PRI_SIMTIME " \n", info.rank, info.thread,
+        getCurrentSimCycle());
     printf("%s\n", msg.c_str());
 
     if ( nullptr == obj_ ) {
         obj_ = getComponentObjectMap();
     }
-    done = false;
+    done     = false;
     retState = -1;
-    
+
 
     // Select the input source and next command line
     std::string line;
@@ -532,28 +533,29 @@ SimpleDebugger::cmd_verbose(std::vector<std::string>& tokens)
 }
 
 void
-SimpleDebugger::cmd_info(std::vector<std::string>& UNUSED(tokens)) {
+SimpleDebugger::cmd_info(std::vector<std::string>& UNUSED(tokens))
+{
 
-    if (tokens.size() != 2) {
+    if ( tokens.size() != 2 ) {
         printf("Invalid format for info command (info \"current\"|\"all\")\n");
         return;
     }
 
-    RankInfo info = getRank();
+    RankInfo info   = getRank();
     RankInfo nRanks = getNumRanks();
-    if (tokens[1] == "current") {
-        std::cout << "Rank " << info.rank << "/" << nRanks.rank
-            << ", Thread " << info.thread << "/" << nRanks.thread << std::endl;
+    if ( tokens[1] == "current" ) {
+        std::cout << "Rank " << info.rank << "/" << nRanks.rank << ", Thread " << info.thread << "/" << nRanks.thread
+                  << std::endl;
     }
-    else if (tokens[1] == "all") {
-        if (nRanks.rank == 1 && nRanks.thread == 1) {
-            std::cout << "Rank " << info.rank << "/" << nRanks.rank
-                << ", Thread " << info.thread << "/" << nRanks.thread << std::endl;
+    else if ( tokens[1] == "all" ) {
+        if ( nRanks.rank == 1 && nRanks.thread == 1 ) {
+            std::cout << "Rank " << info.rank << "/" << nRanks.rank << ", Thread " << info.thread << "/"
+                      << nRanks.thread << std::endl;
         }
         else {
             // Return to syncmanager to print summary for all threads
             retState = -2; // summary info
-            done = true;
+            done     = true;
         }
     }
     else {
@@ -564,40 +566,41 @@ SimpleDebugger::cmd_info(std::vector<std::string>& UNUSED(tokens)) {
 
 // thread <threadID> : switches to new thread
 void
-SimpleDebugger::cmd_thread(std::vector<std::string>& tokens) {
+SimpleDebugger::cmd_thread(std::vector<std::string>& tokens)
+{
 
-    if (tokens.size() != 2) {
+    if ( tokens.size() != 2 ) {
         printf("Invalid format for thread command (thread <threadID>)\n");
         return;
     }
 
-    RankInfo info = getRank();
+    RankInfo info   = getRank();
     RankInfo nRanks = getNumRanks();
-    int threadID;
+    int      threadID;
 
     // Get threadID
     try {
         threadID = std::stoi(tokens[1]);
     }
-    catch (const std::invalid_argument& e) {
+    catch ( const std::invalid_argument& e ) {
         std::cout << "Invalid argument for threadID: " << tokens[1] << std::endl;
         return;
     }
-    catch (const std::out_of_range& e) {
+    catch ( const std::out_of_range& e ) {
         std::cout << "Out of range for threadID: " << tokens[1] << std::endl;
         return;
     }
 
     // Check if valid threadID
-    if (threadID < 0 || threadID >= nRanks.thread) {
-        printf("ThreadID %d out of range (0:%d)\n", threadID, nRanks.thread-1);
+    if ( threadID < 0 || threadID >= nRanks.thread ) {
+        printf("ThreadID %d out of range (0:%d)\n", threadID, nRanks.thread - 1);
         return;
     }
-    
+
     // If not current thread, set retState and done flag
-    if (threadID != info.thread) {
+    if ( threadID != info.thread ) {
         retState = threadID;
-        done = true;
+        done     = true;
     }
     return;
 }
@@ -661,7 +664,7 @@ SimpleDebugger::cmd_cd(std::vector<std::string>& tokens)
     }
 #else
     // skk This works but doesn't delete/deactivate like objmap selectParent
-    if (tokens.size() == 1) {
+    if ( tokens.size() == 1 ) {
         obj_ = getComponentObjectMap();
         return;
     }
@@ -919,20 +922,19 @@ SimpleDebugger::cmd_run(std::vector<std::string>& tokens)
             return;
         }
     }
-    else if (tokens.size() == 3) {
+    else if ( tokens.size() == 3 ) {
         std::string time = tokens[1] + tokens[2];
         try {
-            TimeConverter* tc = getTimeConverter(time);
+            TimeConverter* tc  = getTimeConverter(time);
             std::string    msg = format_string("Running clock %" PRI_SIMTIME " sim cycles", tc->getFactor());
             schedule_interactive(tc->getFactor(), msg);
         }
-        catch (std::exception& e) {
+        catch ( std::exception& e ) {
             printf("Unknown time in call to run: %s\n", time.c_str());
             return;
         }
-
     }
-    else if (tokens.size() != 1) {
+    else if ( tokens.size() != 1 ) {
         printf("Too many arguments for 'run <time>'\n");
     }
 

--- a/src/sst/core/impl/interactive/simpleDebug.h
+++ b/src/sst/core/impl/interactive/simpleDebug.h
@@ -266,7 +266,7 @@ private:
 
     SST::Core::Serialization::ObjectMap* obj_     = nullptr;
     bool                                 done     = false;
-    int                                  retState = -1; // -1 done, positive number is threadID
+    int                                  retState = -1; // -1 DONE, -2 SUMAMRY, positive number is threadID
 
     bool autoCompleteEnable = true;
 

--- a/src/sst/core/impl/interactive/simpleDebug.h
+++ b/src/sst/core/impl/interactive/simpleDebug.h
@@ -250,7 +250,8 @@ public:
     explicit SimpleDebugger(Params& params);
     ~SimpleDebugger();
 
-    void execute(const std::string& msg) override;
+    int execute(const std::string& msg) override;
+    void summary() override;
 
     // Callbacks from command line completions
     void get_listing_strings(std::list<std::string>&);
@@ -265,6 +266,7 @@ private:
 
     SST::Core::Serialization::ObjectMap* obj_ = nullptr;
     bool                                 done = false;
+    int                                  retState = -1; // -1 done, positive number is threadID
 
     bool autoCompleteEnable = true;
 
@@ -297,7 +299,9 @@ private:
 
     // Navigation
     void cmd_help(std::vector<std::string>& UNUSED(tokens));
-    void cmd_verbose(std::vector<std::string>&(tokens));
+    void cmd_verbose(std::vector<std::string>& (tokens));
+    void cmd_info(std::vector<std::string>& UNUSED(tokens));
+    void cmd_thread(std::vector<std::string>& tokens);
     void cmd_pwd(std::vector<std::string>& UNUSED(tokens));
     void cmd_ls(std::vector<std::string>& UNUSED(tokens));
     void cmd_cd(std::vector<std::string>& tokens);

--- a/src/sst/core/impl/interactive/simpleDebug.h
+++ b/src/sst/core/impl/interactive/simpleDebug.h
@@ -250,7 +250,7 @@ public:
     explicit SimpleDebugger(Params& params);
     ~SimpleDebugger();
 
-    int execute(const std::string& msg) override;
+    int  execute(const std::string& msg) override;
     void summary() override;
 
     // Callbacks from command line completions
@@ -264,8 +264,8 @@ private:
     // directory as far as we can.
     std::vector<std::string> name_stack;
 
-    SST::Core::Serialization::ObjectMap* obj_ = nullptr;
-    bool                                 done = false;
+    SST::Core::Serialization::ObjectMap* obj_     = nullptr;
+    bool                                 done     = false;
     int                                  retState = -1; // -1 done, positive number is threadID
 
     bool autoCompleteEnable = true;
@@ -299,7 +299,7 @@ private:
 
     // Navigation
     void cmd_help(std::vector<std::string>& UNUSED(tokens));
-    void cmd_verbose(std::vector<std::string>& (tokens));
+    void cmd_verbose(std::vector<std::string>&(tokens));
     void cmd_info(std::vector<std::string>& UNUSED(tokens));
     void cmd_thread(std::vector<std::string>& tokens);
     void cmd_pwd(std::vector<std::string>& UNUSED(tokens));

--- a/src/sst/core/interactiveAction.h
+++ b/src/sst/core/interactiveAction.h
@@ -15,6 +15,7 @@
 #include "sst/core/action.h"
 // Can include this because this header is not installed
 #include "sst/core/simulation_impl.h"
+#include "sst/core/interactiveConsole.h"
 
 #include <string>
 
@@ -31,7 +32,6 @@ public:
        Create a new InteractiveAction object for the simulation core to initiate interactive mode
     */
     InteractiveAction(Simulation_impl* sim, const std::string& msg) :
-        Action(),
         sim_(sim),
         msg_(msg)
     {
@@ -39,18 +39,47 @@ public:
     }
 
     ~InteractiveAction() {}
+#if 1
+    /**
+       Indicates InteractiveAction should be inserted into the
+       TimeVortex. The insertion will only happen for serial runs, as
+       InteractiveAction is managed by the SyncManager in parallel
+       runs.
+     */
+    void insertIntoTimeVortex(SimTime_t time) {
+        // If this is a serial job, insert this into
+        // the time TimeVortex.  If it is parallel, then the
+        // InteractiveAction is managed by the SyncManager.
+        //std::cout << "skk: insertIntoTimeVortex called\n";
+        RankInfo num_ranks = sim_->getNumRanks();
+        //if (num_ranks.rank == 1 && num_ranks.thread == 1) {
+            //std::cout << "  skk: insertIntoTimeVortex insertActivity\n";
+            sim_->insertActivity(time, this);
+        //}
+    }
+#endif
+#if 0
+    /** Break to interactive console next time check() is called */
+    void setInteractiveConsole() {
+        sim_->enter_interactive_ = true;
+    }
+#endif
 
     /** Called by TimeVortex to trigger interactive mode. */
     void execute() override
     {
         sim_->enter_interactive_ = true;
-        sim_->interactive_msg_   = msg_;
+        sim_->interactive_msg_ = msg_;
         delete this;
     }
+
 
 private:
     Simulation_impl* sim_;
     std::string      msg_;
+    
+    // Do I need flag here for break to interactive like ckptAction?
+    // Currently using sim_->enter_interactive_
 };
 
 } // namespace SST

--- a/src/sst/core/interactiveAction.h
+++ b/src/sst/core/interactiveAction.h
@@ -77,9 +77,6 @@ public:
 private:
     Simulation_impl* sim_;
     std::string      msg_;
-    
-    // Do I need flag here for break to interactive like ckptAction?
-    // Currently using sim_->enter_interactive_
 };
 
 } // namespace SST

--- a/src/sst/core/interactiveConsole.cc
+++ b/src/sst/core/interactiveConsole.cc
@@ -116,7 +116,7 @@ InteractiveConsole::simulationShutdown()
 {
     // Simulation_impl::getSimulation()->endSimulation();  // Only works for single thread
     std::cout << "Simulation shutdown\n";
-    Simulation_impl::getSimulation()->signalShutdown(false); // Works for single thread, hangs for multithread
+    Simulation_impl::getSimulation()->signalShutdown(false);
 }
 
 

--- a/src/sst/core/interactiveConsole.cc
+++ b/src/sst/core/interactiveConsole.cc
@@ -115,8 +115,10 @@ InteractiveConsole::getComponentObjectMap()
 void
 InteractiveConsole::simulationShutdown()
 {
-    //Simulation_impl::getSimulation()->endSimulation();
-    Simulation_impl::getSimulation()->signalShutdown(false);
+    //Simulation_impl::getSimulation()->endSimulation();  // Only works for single thread
+    std::cout << "Simulation shutdown\n";
+    Simulation_impl::getSimulation()->signalShutdown(false);  // Works for single thread, hangs for multithread
+    //Simulation_impl::getSimulation()->setShutdown(false);  // doesn't work for single thread - just keeps running
 }
 
 

--- a/src/sst/core/interactiveConsole.cc
+++ b/src/sst/core/interactiveConsole.cc
@@ -100,6 +100,7 @@ InteractiveConsole::getTimeConverter(const std::string& time)
 void
 InteractiveConsole::schedule_interactive(SimTime_t time_offset, const std::string& msg)
 {
+    //std::cout << "skk: IC: schedule_interactive\n";
     Simulation_impl*   sim = Simulation_impl::getSimulation();
     InteractiveAction* act = new InteractiveAction(sim, msg);
     sim->insertActivity(getCurrentSimCycle() + time_offset, act);
@@ -114,7 +115,8 @@ InteractiveConsole::getComponentObjectMap()
 void
 InteractiveConsole::simulationShutdown()
 {
-    Simulation_impl::getSimulation()->endSimulation();
+    //Simulation_impl::getSimulation()->endSimulation();
+    Simulation_impl::getSimulation()->signalShutdown(false);
 }
 
 

--- a/src/sst/core/interactiveConsole.cc
+++ b/src/sst/core/interactiveConsole.cc
@@ -100,7 +100,6 @@ InteractiveConsole::getTimeConverter(const std::string& time)
 void
 InteractiveConsole::schedule_interactive(SimTime_t time_offset, const std::string& msg)
 {
-    // std::cout << "skk: IC: schedule_interactive\n";
     Simulation_impl*   sim = Simulation_impl::getSimulation();
     InteractiveAction* act = new InteractiveAction(sim, msg);
     sim->insertActivity(getCurrentSimCycle() + time_offset, act);
@@ -118,7 +117,6 @@ InteractiveConsole::simulationShutdown()
     // Simulation_impl::getSimulation()->endSimulation();  // Only works for single thread
     std::cout << "Simulation shutdown\n";
     Simulation_impl::getSimulation()->signalShutdown(false); // Works for single thread, hangs for multithread
-    // Simulation_impl::getSimulation()->setShutdown(false);  // doesn't work for single thread - just keeps running
 }
 
 

--- a/src/sst/core/interactiveConsole.cc
+++ b/src/sst/core/interactiveConsole.cc
@@ -100,7 +100,7 @@ InteractiveConsole::getTimeConverter(const std::string& time)
 void
 InteractiveConsole::schedule_interactive(SimTime_t time_offset, const std::string& msg)
 {
-    //std::cout << "skk: IC: schedule_interactive\n";
+    // std::cout << "skk: IC: schedule_interactive\n";
     Simulation_impl*   sim = Simulation_impl::getSimulation();
     InteractiveAction* act = new InteractiveAction(sim, msg);
     sim->insertActivity(getCurrentSimCycle() + time_offset, act);
@@ -115,10 +115,10 @@ InteractiveConsole::getComponentObjectMap()
 void
 InteractiveConsole::simulationShutdown()
 {
-    //Simulation_impl::getSimulation()->endSimulation();  // Only works for single thread
+    // Simulation_impl::getSimulation()->endSimulation();  // Only works for single thread
     std::cout << "Simulation shutdown\n";
-    Simulation_impl::getSimulation()->signalShutdown(false);  // Works for single thread, hangs for multithread
-    //Simulation_impl::getSimulation()->setShutdown(false);  // doesn't work for single thread - just keeps running
+    Simulation_impl::getSimulation()->signalShutdown(false); // Works for single thread, hangs for multithread
+    // Simulation_impl::getSimulation()->setShutdown(false);  // doesn't work for single thread - just keeps running
 }
 
 

--- a/src/sst/core/interactiveConsole.h
+++ b/src/sst/core/interactiveConsole.h
@@ -57,6 +57,10 @@ public:
     InteractiveConsole()          = default;
     virtual ~InteractiveConsole() = default;
 
+    enum ICretcode {
+        DONE = -1,
+        SUMMARY = -2
+    };
     /** Called by TimeVortex to trigger checkpoint on simulation clock interval - not used in parallel simulation */
     virtual int execute(const std::string& msg) = 0;
     /** Called by SyncManager to get summary info for each thread */

--- a/src/sst/core/interactiveConsole.h
+++ b/src/sst/core/interactiveConsole.h
@@ -58,7 +58,9 @@ public:
     virtual ~InteractiveConsole() = default;
 
     /** Called by TimeVortex to trigger checkpoint on simulation clock interval - not used in parallel simulation */
-    virtual void execute(const std::string& msg) = 0;
+    virtual int execute(const std::string& msg) = 0;
+    /** Called by SyncManager to get summary info for each thread */
+    virtual void summary() = 0;
 
 protected:
     // Functions that can be called by child class

--- a/src/sst/core/interactiveConsole.h
+++ b/src/sst/core/interactiveConsole.h
@@ -57,14 +57,11 @@ public:
     InteractiveConsole()          = default;
     virtual ~InteractiveConsole() = default;
 
-    enum ICretcode {
-        DONE = -1,
-        SUMMARY = -2
-    };
+    enum ICretcode { DONE = -1, SUMMARY = -2 };
     /** Called by TimeVortex to trigger checkpoint on simulation clock interval - not used in parallel simulation */
-    virtual int execute(const std::string& msg) = 0;
+    virtual int  execute(const std::string& msg) = 0;
     /** Called by SyncManager to get summary info for each thread */
-    virtual void summary() = 0;
+    virtual void summary()                       = 0;
 
 protected:
     // Functions that can be called by child class

--- a/src/sst/core/interactiveConsole.h
+++ b/src/sst/core/interactiveConsole.h
@@ -57,6 +57,7 @@ public:
     InteractiveConsole()          = default;
     virtual ~InteractiveConsole() = default;
 
+    /** Interactive Console execute return codes: Positive number is thread ID to switch to, negative is other state */
     enum ICretcode { DONE = -1, SUMMARY = -2 };
     /** Called by TimeVortex to trigger checkpoint on simulation clock interval - not used in parallel simulation */
     virtual int  execute(const std::string& msg) = 0;

--- a/src/sst/core/serialization/objectMap.cc
+++ b/src/sst/core/serialization/objectMap.cc
@@ -167,7 +167,6 @@ ObjectMap::demangle_name(const char* name)
 std::string
 ObjectMap::listVariable(std::string name, bool& found, int recurse)
 {
-    // auto& vars = getVariables();
     ObjectMap* var = findVariable(name);
     if ( nullptr == var ) {
         found = false;

--- a/src/sst/core/serialization/objectMap.cc
+++ b/src/sst/core/serialization/objectMap.cc
@@ -167,12 +167,14 @@ ObjectMap::demangle_name(const char* name)
 std::string
 ObjectMap::listVariable(std::string name, bool& found, int recurse)
 {
+    auto& vars = getVariables();
     ObjectMap* var = findVariable(name);
     if ( nullptr == var ) {
         found = false;
         return "";
     }
     found = true;
+
 
     std::string ret;
 
@@ -204,7 +206,6 @@ ObjectMap::listRecursive(const std::string& name, int level, int recurse)
         ret = format_string("%s%s = %s (%s)\n", indent.c_str(), name.c_str(), get().c_str(), getType().c_str());
         return ret;
     }
-
     ret = format_string("%s%s (%s)\n", indent.c_str(), name.c_str(), getType().c_str());
 
     if ( level <= recurse ) {

--- a/src/sst/core/serialization/objectMap.cc
+++ b/src/sst/core/serialization/objectMap.cc
@@ -167,7 +167,7 @@ ObjectMap::demangle_name(const char* name)
 std::string
 ObjectMap::listVariable(std::string name, bool& found, int recurse)
 {
-    auto& vars = getVariables();
+    // auto& vars = getVariables();
     ObjectMap* var = findVariable(name);
     if ( nullptr == var ) {
         found = false;

--- a/src/sst/core/serialization/objectMap.h
+++ b/src/sst/core/serialization/objectMap.h
@@ -1136,7 +1136,7 @@ public:
             return;
         }
         if ( state_ != CLEAR ) {
-            std::cout << "TriggerRecord:@cycle" << triggerCycle << ": samples lost = " << samplesLost_ << ": ";
+            std::cout << "LastTriggerRecord:@cycle" << triggerCycle << ": SamplesLost=" << samplesLost_ << ": ";
             for ( size_t obj = 0; obj < numObjects; obj++ ) {
                 ObjectBuffer* varBuffer_ = objBuffers_[obj];
                 std::cout << SST::Core::to_string(varBuffer_->getName()) << "=" << varBuffer_->getTriggerVal() << " ";

--- a/src/sst/core/simulation.cc
+++ b/src/sst/core/simulation.cc
@@ -1142,29 +1142,23 @@ Simulation_impl::signalShutdown(bool abnormal)
     else {
         shutdown_mode_ = SHUTDOWN_CLEAN;
     }
-#if 1
-    endSim = true;
-#else
+
     if (num_ranks.rank == 1 && num_ranks.thread == 1) {
+        // Set endsim right away if serial
         endSim = true;
     }
     else {
-        // skk
+        // Otherwise handle shutdown in sync
         enter_shutdown_ = true;
     }
-#endif
+
 }
 
 void
-Simulation_impl::setShutdown(bool abnormal)
+Simulation_impl::setEndSim()
 {
-    if (abnormal) {
-        shutdown_mode_ = SHUTDOWN_SIGNAL;
-    }
-    else {
-        shutdown_mode_ = SHUTDOWN_CLEAN;
-    }
-    enter_shutdown_ = true;
+    // Called from sync
+    endSim = true;
 }
 
 // If this version is called, we need to set the end time in the exit

--- a/src/sst/core/simulation.cc
+++ b/src/sst/core/simulation.cc
@@ -938,6 +938,63 @@ Simulation_impl::prepare_for_run()
 }
 
 void
+Simulation_impl::setup_interactive_mode() {
+
+    
+    // Start just with multithreading right now
+    if (num_ranks.rank == 1) { 
+        //std::cout << "skk: run: setup interactive\n";
+        if (interactive_type_ != "") {
+            // --interactive-console used to override default
+            initialize_interactive_console(interactive_type_);
+        }
+        else if ((interactive_start_ != "") || (config.sigusr1() == "sst.rt.interactive") ||
+            (config.sigusr2() == "sst.rt.interactive")) {
+            // use default interactive console
+            interactive_type_ = "sst.interactive.simpledebug";
+            initialize_interactive_console(interactive_type_);
+        }
+
+        if (interactive_start_ != "") {
+            //std::cout << "skk: run: interactive start\n";
+            if (nullptr == interactive_) { // Should never get here
+                sim_output.fatal(CALL_INFO, 1,
+                    "ERROR: Specified --interactive-start, but did not specify --interactive-mode to set the "
+                    "interactive action that should be used.\n");
+            }
+            SimTime_t offset;
+            try {
+                UnitAlgebra time(interactive_start_);
+                printf("%s\n", time.toStringBestSI().c_str());
+                
+                if (time.isValueZero()) {
+                    offset = 0;
+                }
+                else {
+                    TimeConverter* tc = timeLord.getTimeConverter(time);
+                    offset = tc->getFactor();
+                } 
+            }
+            catch (std::exception& e) {
+                sim_output.fatal(CALL_INFO, 1, "Invalid format for time in interactive start: %s\n", e.what());
+            }
+
+            // Special case, invoke interactive console now rather than wait for sync
+            if (num_ranks.thread > 1 && offset == 0) {
+                enter_interactive_ = true;
+                syncManager->handleInteractiveConsole();
+
+            }
+            else {
+                InteractiveAction* act =
+                    new InteractiveAction(this, format_string("Interactive start at %" PRI_SIMTIME, offset));
+                act->insertIntoTimeVortex(currentSimCycle + offset);
+            }
+        }
+    }
+}
+
+void
 Simulation_impl::run()
 {
 #if SST_PERFORMANCE_INSTRUMENTING
@@ -954,47 +1011,7 @@ Simulation_impl::run()
 #endif
 #endif
 
-    // Setup interactive mode (only in serial jobs for now)
-    if ( num_ranks.rank == 1 && num_ranks.thread == 1 ) {
-        if ( interactive_type_ != "" ) {
-            // --interactive-console used to override default
-            initialize_interactive_console(interactive_type_);
-        }
-        else if ( (interactive_start_ != "") || (config.sigusr1() == "sst.rt.interactive") ||
-                  (config.sigusr2() == "sst.rt.interactive") ) {
-            // use default interactive console
-            interactive_type_ = "sst.interactive.simpledebug";
-            initialize_interactive_console(interactive_type_);
-        }
-
-        if ( interactive_start_ != "" ) {
-            if ( nullptr == interactive_ ) { // Should never get here
-                sim_output.fatal(CALL_INFO, 1,
-                    "ERROR: Specified --interactive-start, but did not specify --interactive-mode to set the "
-                    "interactive action that should be used.\n");
-            }
-            try {
-                UnitAlgebra time(interactive_start_);
-                printf("%s\n", time.toStringBestSI().c_str());
-                SimTime_t offset;
-                if ( time.isValueZero() ) {
-                    offset = 0;
-                }
-                else {
-                    TimeConverter* tc = timeLord.getTimeConverter(time);
-                    offset            = tc->getFactor();
-                }
-
-                InteractiveAction* act =
-                    new InteractiveAction(this, format_string("Interactive start at %" PRI_SIMTIME, offset));
-                act->setDeliveryTime(currentSimCycle + offset);
-                timeVortex->insert(act);
-            }
-            catch ( const std::exception& e ) {
-                sim_output.fatal(CALL_INFO, 1, "Invalid format for time in interactive start: %s\n", e.what());
-            }
-        }
-    }
+    setup_interactive_mode();
 
     run_phase_start_time_ = sst_get_cpu_time();
 
@@ -1034,10 +1051,13 @@ Simulation_impl::run()
                 signal_arrived_ = 0;
                 real_time_->notifySignal();
             }
-            if ( enter_interactive_ ) {
-                enter_interactive_ = false;
-                if ( interactive_ != nullptr ) interactive_->execute(interactive_msg_);
-            }
+            // If serial execution (1 rank, 1 thread)
+            if ((num_ranks.rank == 1) && (num_ranks.thread == 1)) {
+                if (enter_interactive_) {
+                    enter_interactive_ = false;
+                    if (interactive_ != nullptr) interactive_->execute(interactive_msg_);
+                }
+            } // Otherwise handled in sync manager
         }
 
 #if SST_PERIODIC_PRINT
@@ -1068,7 +1088,6 @@ Simulation_impl::run()
     }
 
     /* We shouldn't need to do this, but to be safe... */
-
     runBarrier.wait(); // TODO<- Is this needed?
 
     run_phase_total_time_ = sst_get_cpu_time() - run_phase_start_time_;
@@ -1123,7 +1142,29 @@ Simulation_impl::signalShutdown(bool abnormal)
     else {
         shutdown_mode_ = SHUTDOWN_CLEAN;
     }
+#if 1
     endSim = true;
+#else
+    if (num_ranks.rank == 1 && num_ranks.thread == 1) {
+        endSim = true;
+    }
+    else {
+        // skk
+        enter_shutdown_ = true;
+    }
+#endif
+}
+
+void
+Simulation_impl::setShutdown(bool abnormal)
+{
+    if (abnormal) {
+        shutdown_mode_ = SHUTDOWN_SIGNAL;
+    }
+    else {
+        shutdown_mode_ = SHUTDOWN_CLEAN;
+    }
+    enter_shutdown_ = true;
 }
 
 // If this version is called, we need to set the end time in the exit
@@ -2139,6 +2180,14 @@ Simulation_impl::initialize_interactive_console(const std::string& type)
     if ( replay_file_.size() > 0 ) p.insert("replayFile", replay_file_);
 
     interactive_ = factory->Create<InteractiveConsole>(actual_type, p);
+}
+
+void
+Simulation_impl::scheduleInteractiveConsole(const std::string& msg)
+{
+    //std::cout << "skk: scheduleIC\n";
+    enter_interactive_ = true;
+    interactive_msg_ = msg;
 }
 
 

--- a/src/sst/core/simulation.cc
+++ b/src/sst/core/simulation.cc
@@ -938,26 +938,27 @@ Simulation_impl::prepare_for_run()
 }
 
 void
-Simulation_impl::setup_interactive_mode() {
+Simulation_impl::setup_interactive_mode()
+{
 
-    
+
     // Start just with multithreading right now
-    if (num_ranks.rank == 1) { 
-        //std::cout << "skk: run: setup interactive\n";
-        if (interactive_type_ != "") {
+    if ( num_ranks.rank == 1 ) {
+        // std::cout << "skk: run: setup interactive\n";
+        if ( interactive_type_ != "" ) {
             // --interactive-console used to override default
             initialize_interactive_console(interactive_type_);
         }
-        else if ((interactive_start_ != "") || (config.sigusr1() == "sst.rt.interactive") ||
-            (config.sigusr2() == "sst.rt.interactive")) {
+        else if ( (interactive_start_ != "") || (config.sigusr1() == "sst.rt.interactive") ||
+                  (config.sigusr2() == "sst.rt.interactive") ) {
             // use default interactive console
             interactive_type_ = "sst.interactive.simpledebug";
             initialize_interactive_console(interactive_type_);
         }
 
-        if (interactive_start_ != "") {
-            //std::cout << "skk: run: interactive start\n";
-            if (nullptr == interactive_) { // Should never get here
+        if ( interactive_start_ != "" ) {
+            // std::cout << "skk: run: interactive start\n";
+            if ( nullptr == interactive_ ) { // Should never get here
                 sim_output.fatal(CALL_INFO, 1,
                     "ERROR: Specified --interactive-start, but did not specify --interactive-mode to set the "
                     "interactive action that should be used.\n");
@@ -966,24 +967,23 @@ Simulation_impl::setup_interactive_mode() {
             try {
                 UnitAlgebra time(interactive_start_);
                 printf("%s\n", time.toStringBestSI().c_str());
-                
-                if (time.isValueZero()) {
+
+                if ( time.isValueZero() ) {
                     offset = 0;
                 }
                 else {
                     TimeConverter* tc = timeLord.getTimeConverter(time);
-                    offset = tc->getFactor();
-                } 
+                    offset            = tc->getFactor();
+                }
             }
-            catch (std::exception& e) {
+            catch ( std::exception& e ) {
                 sim_output.fatal(CALL_INFO, 1, "Invalid format for time in interactive start: %s\n", e.what());
             }
 
             // Special case, invoke interactive console now rather than wait for sync
-            if (num_ranks.thread > 1 && offset == 0) {
+            if ( num_ranks.thread > 1 && offset == 0 ) {
                 enter_interactive_ = true;
                 syncManager->handleInteractiveConsole();
-
             }
             else {
                 InteractiveAction* act =
@@ -1052,10 +1052,10 @@ Simulation_impl::run()
                 real_time_->notifySignal();
             }
             // If serial execution (1 rank, 1 thread)
-            if ((num_ranks.rank == 1) && (num_ranks.thread == 1)) {
-                if (enter_interactive_) {
+            if ( (num_ranks.rank == 1) && (num_ranks.thread == 1) ) {
+                if ( enter_interactive_ ) {
                     enter_interactive_ = false;
-                    if (interactive_ != nullptr) interactive_->execute(interactive_msg_);
+                    if ( interactive_ != nullptr ) interactive_->execute(interactive_msg_);
                 }
             } // Otherwise handled in sync manager
         }
@@ -1143,7 +1143,7 @@ Simulation_impl::signalShutdown(bool abnormal)
         shutdown_mode_ = SHUTDOWN_CLEAN;
     }
 
-    if (num_ranks.rank == 1 && num_ranks.thread == 1) {
+    if ( num_ranks.rank == 1 && num_ranks.thread == 1 ) {
         // Set endsim right away if serial
         endSim = true;
     }
@@ -1151,7 +1151,6 @@ Simulation_impl::signalShutdown(bool abnormal)
         // Otherwise handle shutdown in sync
         enter_shutdown_ = true;
     }
-
 }
 
 void
@@ -2179,9 +2178,9 @@ Simulation_impl::initialize_interactive_console(const std::string& type)
 void
 Simulation_impl::scheduleInteractiveConsole(const std::string& msg)
 {
-    //std::cout << "skk: scheduleIC\n";
+    // std::cout << "skk: scheduleIC\n";
     enter_interactive_ = true;
-    interactive_msg_ = msg;
+    interactive_msg_   = msg;
 }
 
 

--- a/src/sst/core/simulation_impl.h
+++ b/src/sst/core/simulation_impl.h
@@ -484,7 +484,7 @@ public:
     * Called when action needs to terminate SST 
     * sets a flag to trigger shutdown at sync, but doesn't endSim
     */
-    void setShutdown(bool abnormal);
+    void setEndSim();
 
     /** Normal Shutdown
      */

--- a/src/sst/core/simulation_impl.h
+++ b/src/sst/core/simulation_impl.h
@@ -242,6 +242,8 @@ public:
 
     void prepare_for_run();
 
+    void setup_interactive_mode();
+
     void run();
 
     void finish();
@@ -403,6 +405,7 @@ public:
 
     std::string initializeCheckpointInfrastructure(const std::string& prefix);
     void        scheduleCheckpoint();
+    void        scheduleInteractiveConsole(const std::string& msg);
 
     /**
        Write the partition specific checkpoint data
@@ -477,6 +480,12 @@ public:
      */
     void signalShutdown(bool abnormal);
 
+    /** Set Shutdown
+    * Called when action needs to terminate SST 
+    * sets a flag to trigger shutdown at sync, but doesn't endSim
+    */
+    void setShutdown(bool abnormal);
+
     /** Normal Shutdown
      */
     void endSimulation();
@@ -511,6 +520,7 @@ public:
     unsigned int            untimed_phase;
     volatile sig_atomic_t   signal_arrived_; // true if a signal has arrived
     ShutdownMode_t          shutdown_mode_;
+    bool                    enter_shutdown_ = false;
     bool                    wireUpFinished_;
     RealTimeManager*        real_time_;
     std::string             interactive_type_  = "";

--- a/src/sst/core/simulation_impl.h
+++ b/src/sst/core/simulation_impl.h
@@ -480,9 +480,8 @@ public:
      */
     void signalShutdown(bool abnormal);
 
-    /** Set Shutdown
-     * Called when action needs to terminate SST
-     * sets a flag to trigger shutdown at sync, but doesn't endSim
+    /** Set EndSim
+     * Called by SyncMgr when interactive console ready to shutdown
      */
     void setEndSim();
 

--- a/src/sst/core/simulation_impl.h
+++ b/src/sst/core/simulation_impl.h
@@ -481,9 +481,9 @@ public:
     void signalShutdown(bool abnormal);
 
     /** Set Shutdown
-    * Called when action needs to terminate SST 
-    * sets a flag to trigger shutdown at sync, but doesn't endSim
-    */
+     * Called when action needs to terminate SST
+     * sets a flag to trigger shutdown at sync, but doesn't endSim
+     */
     void setEndSim();
 
     /** Normal Shutdown

--- a/src/sst/core/sync/syncManager.cc
+++ b/src/sst/core/sync/syncManager.cc
@@ -15,6 +15,7 @@
 
 #include "sst/core/checkpointAction.h"
 #include "sst/core/exit.h"
+#include "sst/core/interactiveConsole.h"
 #include "sst/core/objectComms.h"
 #include "sst/core/profile/syncProfileTool.h"
 #include "sst/core/realtime.h"
@@ -152,6 +153,7 @@ public:
     void before() override {}
     void after() override {}
     void execute() override {}
+    //void bwait() override {}
     void processLinkUntimedData() override {}
     void finalizeLinkConfigurations() override {}
     void prepareForComplete() override {}
@@ -324,8 +326,11 @@ SyncManager::SyncManager(const RankInfo& rank, const RankInfo& num_ranks, SimTim
 
     exit_       = sim_->getExit();
     checkpoint_ = sim_->getCheckpointAction();
+    ic_barrier_.resize(num_ranks_.thread);
 
     setPriority(SYNCPRIORITY);
+
+    //sim_->getSimulationOutput().output("skk:syncmgr:constructor: T%d\n", rank_.thread);
 }
 
 SyncManager::SyncManager()
@@ -366,6 +371,140 @@ SyncManager::exchangeLinkInfo()
 }
 
 void
+SyncManager::handleShutdown() {
+
+    //ic_barrier_.wait(); // SKK This one may not be necessary...
+    if (num_ranks_.thread > 1) {
+#if 0
+        // Check for shutdown
+        Output& out = sim_->getSimulationOutput();
+        out.output("skk:syncmgr:execute: T%d:endSim=%d, shutdown_mode=%d\n", rank_.thread, sim_->endSim, sim_->shutdown_mode_);
+#endif
+        //if (sim_->endSim == true) {
+        if (sim_->enter_shutdown_ == true) {
+            enter_shutdown_.fetch_or(true);
+            endSim_.fetch_or(true);
+            if (sim_->shutdown_mode_ == true) {
+                shutdown_mode_.store(true);
+            }
+        }
+        ic_barrier_.wait();
+        if (endSim_ == true) {
+            sim_->signalShutdown(shutdown_mode_.load());
+        }
+    }
+}
+
+void
+SyncManager::handleInteractiveConsole()
+{
+    ic_barrier_.wait(); // SKK This one may not be necessary...
+
+    // Handle interactive console
+    if (num_ranks_.thread > 1) {
+
+        // 1) Check enter interactive and set mask if needed
+        if (sim_->enter_interactive_ == true) {
+            unsigned bit = 1UL << rank_.thread;
+            enter_interactive_mask_.fetch_or(bit);
+        }
+        ic_barrier_.wait();  // Ensure everyone has written the mask before checking
+
+        // If enter interactive set for any thread
+        unsigned ic_mask = enter_interactive_mask_.load();
+        //out.output("skk:syncmgr:execute: T%d: check enter_interactive_=%d\n", rank_.thread, sim_->enter_interactive_);
+        //out.output("skk:syncmgr:execute: T%d: enter_interactive_mask_=0x%x\n", rank_.thread, ic_mask);
+        if (ic_mask) {
+            // 2) Print list of threads and whether triggered
+            for (uint32_t tindex = 0; tindex < num_ranks_.thread; tindex++) {
+                // Actually, not true, we want them to print in order
+                if (rank_.thread == tindex) {
+                    if (rank_.thread == 0)
+                        std::cout << "\nINTERACTIVE CONSOLE\n";
+                    std::cout << "  Rank:" << rank_.rank << "/" << num_ranks_.rank
+                        << " Thread:" << rank_.thread << "/" << num_ranks_.thread;
+                    if (sim_->enter_interactive_) {
+                        std::cout << " (Triggered)\n";
+                    }
+                    else {
+                        std::cout << " (Not Triggered)\n";
+                    }
+#if 0                       // Print component summary - will be at whatever level was last (maybe print PWD instead?)
+                    if (sim_->interactive_ != nullptr) {
+                        sim_->interactive_->summary();
+                    }
+#endif
+                }
+                ic_barrier_.wait();
+            }
+
+            // 3) T0: Invoke IC for T0 (or Query which thread to inspect?)
+#if 0
+            if (rank_.thread == 0) {
+                current_ic_thread_ = num_ranks_.thread;
+                std::cout << "\n---- Enter thread ID (0 to " << num_ranks_.thread - 1 << ") to inspect in interactive console or "
+                    << num_ranks_.thread << " to continue simulation\n";
+                std::cin >> current_ic_thread_;
+                std::cout << "skk: set tid to " << current_ic_thread_ << std::endl;
+            }
+            ic_barrier_.wait();
+#else
+            if (rank_.thread == 0) {
+                current_ic_thread_.store(0);
+            }
+            ic_barrier_.wait();  // Ensure store is complete before everyone checks
+#endif
+
+            // 4) Tj: Invoke IC for current thread, with ability to change to new thread
+            int tid = current_ic_thread_.load();
+            int ic_state = 0;// interactive_state_.load();
+            while (ic_state != -1) {
+                if ((rank_.thread == tid) && (sim_->interactive_ != nullptr)) {
+                    int result = sim_->interactive_->execute(sim_->interactive_msg_);
+
+                    if (result >= 0) { // change thread
+                        current_ic_thread_.store(result);
+                        current_ic_state_.store(0);
+                    }
+                    else { // -1 done, -2 print summary
+                        current_ic_state_.store(result);
+                    }
+                }
+                ic_barrier_.wait();
+                tid = current_ic_thread_.load();
+                ic_state = current_ic_state_.load();
+                //out.output("T%d: tid %d, ic_state %d\n", rank_.thread, tid, ic_state);
+                if (ic_state == -2) {  // Print thread info summary
+                    for (uint32_t tindex = 0; tindex < num_ranks_.thread; tindex++) {
+                        if (rank_.thread == tindex) {
+                            std::cout << "Rank:" << rank_.rank << " Thread:" << rank_.thread;
+                            // Print component summary
+                            if (sim_->interactive_ != nullptr) {
+                                sim_->interactive_->summary();
+                            }
+                        }
+                        ic_barrier_.wait();
+                    }
+                    current_ic_state_.store(0);
+                }  // if state == -2, print thread info summary
+            }
+
+            // 5) When done, clear interactive mask and enter interactive flags for next round
+            if (rank_.thread == 0) {
+                enter_interactive_mask_.store(0);
+            }
+            sim_->enter_interactive_ = false;
+            ic_barrier_.wait();
+            ic_mask = enter_interactive_mask_.load();
+            //out.output("skk:syncmgr:execute: T%d: After: check enter_interactive_=%d\n", rank_.thread, sim_->enter_interactive_);
+            //out.output("skk:syncmgr:execute: T%d: AFter: enter_interactive_mask_=0x%x\n", rank_.thread, ic_mask);   
+        }
+    } // end if num_ranks_.thread > 1: Handle interactive console
+      // SKK Serial execution handles this in run so it happens right away
+
+}
+
+void
 SyncManager::execute()
 {
     SST_SYNC_PROFILE_START
@@ -376,6 +515,7 @@ SyncManager::execute()
     int  sig_end;
     int  sig_usr;
     int  sig_alrm;
+    
 
     SimTime_t next_checkpoint_time = MAX_SIMTIME_T;
 
@@ -423,8 +563,29 @@ SyncManager::execute()
             if ( sig_alrm ) real_time_->performSignal(sig_alrm);
         }
 
+        
         // Generate checkpoint if needed
         next_checkpoint_time = checkpoint_->check(getDeliveryTime());
+
+        
+#if 1
+        // SKK Hmmm, should interactive check be before checkpoint in case it want to generate checkpoint?
+        // No it should have already scheduled the checkpoint when the watchpoint was hit
+
+        // Handle interactive console - Not even testable yet...   
+        // SKK If we had an interactive_action, we could call check()
+        //interactive_action_->check(getDeliveryTime());
+        // Need barrier here
+        if (rank_.thread == 0) {
+            //std::cout << "skk: syncmgr rank: t0: interactive execute\n";
+            if (sim_->enter_interactive_ == true) {
+                sim_->enter_interactive_ = false; // IC may schedule IC again
+                if (sim_->interactive_ != nullptr)
+                    sim_->interactive_->execute(sim_->interactive_msg_);
+            }
+        }
+        
+#endif
 
         // No barrier needed. Either the check failed and no
         // checkpoint happened, so no global activity, or the
@@ -445,11 +606,16 @@ SyncManager::execute()
             real_time_->getSignals(sig_end, sig_usr, sig_alrm);
             threadSync_->setSignals(sig_end, sig_usr, sig_alrm);
         }
-        threadSync_->execute();
+        threadSync_->execute();  // exchange event queues
 
         // Handle signals for multi-threaded runs/no MPI
         if ( num_ranks_.rank == 1 ) {
             signals_received = threadSync_->getSignals(sig_end, sig_usr, sig_alrm);
+#if 0
+            Output& out = sim_->getSimulationOutput();
+            out.output("skk:syncmgr:execute: T%d: sig_end=%d, sig_usr=%d, sig_alrm=%d, received=%d\n", 
+               rank_.thread, sig_end, sig_usr, sig_alrm, signals_received);
+#endif
             if ( sig_end )
                 real_time_->performSignal(sig_end);
             else if ( signals_received ) {
@@ -457,19 +623,21 @@ SyncManager::execute()
                 if ( sig_alrm ) real_time_->performSignal(sig_alrm);
             }
             next_checkpoint_time = checkpoint_->check(getDeliveryTime());
-        }
+             
+            handleShutdown();
+            handleInteractiveConsole();
+
+        } // if num_ranks_.rank == 1 i.e. only multithreading
 
         if ( /*num_ranks_+.rank == 1*/ min_part_ == MAX_SIMTIME_T ) {
             if ( exit_->getRefCount() == 0 ) {
                 endSimulation(exit_->getEndTime());
             }
         }
-
-
         break;
     default:
         break;
-    }
+    }  // end switch
     computeNextInsert(next_checkpoint_time);
     RankExecBarrier_[4].wait();
 
@@ -563,5 +731,14 @@ SyncManager::addProfileTool(Profile::SyncProfileTool* tool)
     if ( !profile_tools_ ) profile_tools_ = new SyncProfileToolList();
     profile_tools_->addProfileTool(tool);
 }
+
+std::atomic<unsigned> SyncManager::enter_interactive_mask_{ 0 };
+std::atomic<int> SyncManager::current_ic_thread_{0};
+std::atomic<int> SyncManager::current_ic_state_{0};
+std::atomic<unsigned> SyncManager::enter_shutdown_{ 0 };
+std::atomic<unsigned> SyncManager::endSim_{ false };
+std::atomic<unsigned> SyncManager::shutdown_mode_{ false };
+Core::ThreadSafe::Barrier SyncManager::ic_barrier_;
+
 
 } // namespace SST

--- a/src/sst/core/sync/syncManager.cc
+++ b/src/sst/core/sync/syncManager.cc
@@ -374,13 +374,13 @@ void
 SyncManager::handleShutdown() {
 
     //ic_barrier_.wait(); // SKK This one may not be necessary...
-    if (num_ranks_.thread > 1) {
 #if 0
         // Check for shutdown
         Output& out = sim_->getSimulationOutput();
-        out.output("skk:syncmgr:execute: T%d:endSim=%d, shutdown_mode=%d\n", rank_.thread, sim_->endSim, sim_->shutdown_mode_);
+        out.output("skk:syncmgr:handleShutdown:Before T%d:endSim=%d, shutdown_mode=%d, enter_shutdown=%d, \n", 
+            rank_.thread, sim_->endSim, sim_->shutdown_mode_, sim_->enter_shutdown_);
 #endif
-        //if (sim_->endSim == true) {
+        // If my thread enter_shutdown_ is true, then set shared enter_shutdown
         if (sim_->enter_shutdown_ == true) {
             enter_shutdown_.fetch_or(true);
             endSim_.fetch_or(true);
@@ -390,9 +390,9 @@ SyncManager::handleShutdown() {
         }
         ic_barrier_.wait();
         if (endSim_ == true) {
-            sim_->signalShutdown(shutdown_mode_.load());
+            sim_->setEndSim();
+
         }
-    }
 }
 
 void
@@ -403,7 +403,7 @@ SyncManager::handleInteractiveConsole()
     // Handle interactive console
     if (num_ranks_.thread > 1) {
 
-        // 1) Check enter interactive and set mask if needed
+        // 1) Check enter interactive and set mask if needed (could use mask to show triggers)
         if (sim_->enter_interactive_ == true) {
             unsigned bit = 1UL << rank_.thread;
             enter_interactive_mask_.fetch_or(bit);
@@ -412,8 +412,11 @@ SyncManager::handleInteractiveConsole()
 
         // If enter interactive set for any thread
         unsigned ic_mask = enter_interactive_mask_.load();
-        //out.output("skk:syncmgr:execute: T%d: check enter_interactive_=%d\n", rank_.thread, sim_->enter_interactive_);
-        //out.output("skk:syncmgr:execute: T%d: enter_interactive_mask_=0x%x\n", rank_.thread, ic_mask);
+#if 0
+        Output& out = sim_->getSimulationOutput();
+        out.output("skk:syncmgr:execute: T%d: check enter_interactive_=%d\n", rank_.thread, sim_->enter_interactive_);
+        out.output("skk:syncmgr:execute: T%d: enter_interactive_mask_=0x%x\n", rank_.thread, ic_mask);
+#endif
         if (ic_mask) {
             // 2) Print list of threads and whether triggered
             for (uint32_t tindex = 0; tindex < num_ranks_.thread; tindex++) {
@@ -429,7 +432,7 @@ SyncManager::handleInteractiveConsole()
                     else {
                         std::cout << " (Not Triggered)\n";
                     }
-#if 0                       // Print component summary - will be at whatever level was last (maybe print PWD instead?)
+#if 0               // Print component summary? - will be at whatever level was last (maybe print PWD instead?)
                     if (sim_->interactive_ != nullptr) {
                         sim_->interactive_->summary();
                     }
@@ -456,13 +459,14 @@ SyncManager::handleInteractiveConsole()
 #endif
 
             // 4) Tj: Invoke IC for current thread, with ability to change to new thread
-            int tid = current_ic_thread_.load();
+            unsigned int tid = current_ic_thread_.load();
             int ic_state = 0;// interactive_state_.load();
             while (ic_state != -1) {
                 if ((rank_.thread == tid) && (sim_->interactive_ != nullptr)) {
+                    // Invoke IC for the thread
                     int result = sim_->interactive_->execute(sim_->interactive_msg_);
 
-                    if (result >= 0) { // change thread
+                    if (result >= 0) { // change thread to threadID <result>
                         current_ic_thread_.store(result);
                         current_ic_state_.store(0);
                     }
@@ -471,6 +475,7 @@ SyncManager::handleInteractiveConsole()
                     }
                 }
                 ic_barrier_.wait();
+                handleShutdown();  // Check if console issued shutdown command
                 tid = current_ic_thread_.load();
                 ic_state = current_ic_state_.load();
                 //out.output("T%d: tid %d, ic_state %d\n", rank_.thread, tid, ic_state);
@@ -611,7 +616,7 @@ SyncManager::execute()
         // Handle signals for multi-threaded runs/no MPI
         if ( num_ranks_.rank == 1 ) {
             signals_received = threadSync_->getSignals(sig_end, sig_usr, sig_alrm);
-#if 0
+#if 1
             Output& out = sim_->getSimulationOutput();
             out.output("skk:syncmgr:execute: T%d: sig_end=%d, sig_usr=%d, sig_alrm=%d, received=%d\n", 
                rank_.thread, sig_end, sig_usr, sig_alrm, signals_received);

--- a/src/sst/core/sync/syncManager.cc
+++ b/src/sst/core/sync/syncManager.cc
@@ -156,7 +156,6 @@ public:
     void before() override {}
     void after() override {}
     void execute() override {}
-    // void bwait() override {}
     void processLinkUntimedData() override {}
     void finalizeLinkConfigurations() override {}
     void prepareForComplete() override {}
@@ -575,13 +574,7 @@ SyncManager::execute()
 
 
 #if 1
-        // SKK Hmmm, should interactive check be before checkpoint in case it want to generate checkpoint?
-        // No it should have already scheduled the checkpoint when the watchpoint was hit
-
-        // Handle interactive console - Not even testable yet...
-        // SKK If we had an interactive_action, we could call check()
-        // interactive_action_->check(getDeliveryTime());
-        // Need barrier here
+        // Handle interactive console
         if ( rank_.thread == 0 ) {
             // std::cout << "skk: syncmgr rank: t0: interactive execute\n";
             if ( sim_->enter_interactive_ == true ) {

--- a/src/sst/core/sync/syncManager.cc
+++ b/src/sst/core/sync/syncManager.cc
@@ -34,6 +34,8 @@
 
 namespace SST {
 
+class InteractiveConsole;
+
 // Static data members
 RankSync*                 SyncManager::rankSync_ = nullptr;
 Core::ThreadSafe::Barrier SyncManager::RankExecBarrier_[5];
@@ -373,15 +375,13 @@ SyncManager::exchangeLinkInfo()
 void
 SyncManager::handleShutdown()
 {
-
-    // ic_barrier_.wait(); // SKK This one may not be necessary...
 #if 0
         // Check for shutdown
         Output& out = sim_->getSimulationOutput();
         out.output("skk:syncmgr:handleShutdown:Before T%d:endSim=%d, shutdown_mode=%d, enter_shutdown=%d, \n", 
             rank_.thread, sim_->endSim, sim_->shutdown_mode_, sim_->enter_shutdown_);
 #endif
-    // If my thread enter_shutdown_ is true, then set shared enter_shutdown
+    // If my thread's enter_shutdown_ is true, then set shared enter_shutdown
     if ( sim_->enter_shutdown_ == true ) {
         enter_shutdown_.fetch_or(true);
         endSim_.fetch_or(true);
@@ -400,17 +400,18 @@ SyncManager::handleInteractiveConsole()
 {
     ic_barrier_.wait(); // SKK This one may not be necessary...
 
-    // Handle interactive console
+    // Handle interactive console for multithreaded runs
+    // Serial execution handles this in simulation run so it happens right away
     if ( num_ranks_.thread > 1 ) {
 
-        // 1) Check enter interactive and set mask if needed (could use mask to show triggers)
+        // 1) Check local enter_interactive_ and set mask if needed (could use mask to show triggers)
         if ( sim_->enter_interactive_ == true ) {
             unsigned bit = 1UL << rank_.thread;
             enter_interactive_mask_.fetch_or(bit);
         }
         ic_barrier_.wait(); // Ensure everyone has written the mask before checking
 
-        // If enter interactive set for any thread
+        // If enter interactive set for any thread, set shared ic_mask
         unsigned ic_mask = enter_interactive_mask_.load();
 #if 0
         Output& out = sim_->getSimulationOutput();
@@ -418,13 +419,13 @@ SyncManager::handleInteractiveConsole()
         out.output("skk:syncmgr:execute: T%d: enter_interactive_mask_=0x%x\n", rank_.thread, ic_mask);
 #endif
         if ( ic_mask ) {
-            // 2) Print list of threads and whether triggered
+            // 2) Print list of threads (in order) and whether triggered
             for ( uint32_t tindex = 0; tindex < num_ranks_.thread; tindex++ ) {
-                // Actually, not true, we want them to print in order
                 if ( rank_.thread == tindex ) {
                     if ( rank_.thread == 0 ) std::cout << "\nINTERACTIVE CONSOLE\n";
-                    std::cout << "  Rank:" << rank_.rank << "/" << num_ranks_.rank << " Thread:" << rank_.thread << "/"
-                              << num_ranks_.thread;
+                    std::cout << "  Rank:" << rank_.rank << "/" << num_ranks_.rank 
+                        << " Thread:" << rank_.thread << "/"
+                        << num_ranks_.thread;
                     if ( sim_->enter_interactive_ ) {
                         std::cout << " (Triggered)\n";
                     }
@@ -440,8 +441,13 @@ SyncManager::handleInteractiveConsole()
                 ic_barrier_.wait();
             }
 
-            // 3) T0: Invoke IC for T0 (or Query which thread to inspect?)
-#if 0
+            // 3) T0: Invoke IC for T0 (or Query which thread to inspect?)    
+#if 1
+            if ( rank_.thread == 0 ) {
+                current_ic_thread_.store(0);
+            }
+            ic_barrier_.wait(); // Ensure store is complete before everyone checks
+#else
             if (rank_.thread == 0) {
                 current_ic_thread_ = num_ranks_.thread;
                 std::cout << "\n---- Enter thread ID (0 to " << num_ranks_.thread - 1 << ") to inspect in interactive console or "
@@ -450,35 +456,30 @@ SyncManager::handleInteractiveConsole()
                 std::cout << "skk: set tid to " << current_ic_thread_ << std::endl;
             }
             ic_barrier_.wait();
-#else
-            if ( rank_.thread == 0 ) {
-                current_ic_thread_.store(0);
-            }
-            ic_barrier_.wait(); // Ensure store is complete before everyone checks
 #endif
-
             // 4) Tj: Invoke IC for current thread, with ability to change to new thread
             unsigned int tid      = current_ic_thread_.load();
-            int          ic_state = 0; // interactive_state_.load();
-            while ( ic_state != -1 ) {
+            int          ic_state = 0;
+            while ( ic_state != InteractiveConsole::ICretcode::DONE ) {
                 if ( (rank_.thread == tid) && (sim_->interactive_ != nullptr) ) {
-                    // Invoke IC for the thread
+                    // Invoke IC for the thread and capture return state
                     int result = sim_->interactive_->execute(sim_->interactive_msg_);
 
                     if ( result >= 0 ) { // change thread to threadID <result>
                         current_ic_thread_.store(result);
                         current_ic_state_.store(0);
                     }
-                    else { // -1 done, -2 print summary
+                    else { // DONE (-1) or Print SUMMARY (-2)
                         current_ic_state_.store(result);
                     }
                 }
                 ic_barrier_.wait();
                 handleShutdown(); // Check if console issued shutdown command
+
                 tid      = current_ic_thread_.load();
                 ic_state = current_ic_state_.load();
                 // out.output("T%d: tid %d, ic_state %d\n", rank_.thread, tid, ic_state);
-                if ( ic_state == -2 ) { // Print thread info summary
+                if ( ic_state ==  InteractiveConsole::ICretcode::SUMMARY ) { // Print thread info summary
                     for ( uint32_t tindex = 0; tindex < num_ranks_.thread; tindex++ ) {
                         if ( rank_.thread == tindex ) {
                             std::cout << "Rank:" << rank_.rank << " Thread:" << rank_.thread;
@@ -490,7 +491,7 @@ SyncManager::handleInteractiveConsole()
                         ic_barrier_.wait();
                     }
                     current_ic_state_.store(0);
-                } // if state == -2, print thread info summary
+                } // if state == SUMMARY, print thread info summary
             }
 
             // 5) When done, clear interactive mask and enter interactive flags for next round
@@ -504,8 +505,7 @@ SyncManager::handleInteractiveConsole()
             // sim_->enter_interactive_); out.output("skk:syncmgr:execute: T%d: AFter: enter_interactive_mask_=0x%x\n",
             // rank_.thread, ic_mask);
         }
-    } // end if num_ranks_.thread > 1: Handle interactive console
-      // SKK Serial execution handles this in run so it happens right away
+    } // end if num_ranks_.thread > 1: Handle interactive console  
 }
 
 void
@@ -614,7 +614,7 @@ SyncManager::execute()
         // Handle signals for multi-threaded runs/no MPI
         if ( num_ranks_.rank == 1 ) {
             signals_received = threadSync_->getSignals(sig_end, sig_usr, sig_alrm);
-#if 1
+#if 0
             Output& out = sim_->getSimulationOutput();
             out.output("skk:syncmgr:execute: T%d: sig_end=%d, sig_usr=%d, sig_alrm=%d, received=%d\n", rank_.thread,
                 sig_end, sig_usr, sig_alrm, signals_received);
@@ -627,8 +627,8 @@ SyncManager::execute()
             }
             next_checkpoint_time = checkpoint_->check(getDeliveryTime());
 
-            handleShutdown();
-            handleInteractiveConsole();
+            handleShutdown();  // Check if any thread set shutdown
+            handleInteractiveConsole();  // Check of any thread set interactive console
 
         } // if num_ranks_.rank == 1 i.e. only multithreading
 

--- a/src/sst/core/sync/syncManager.cc
+++ b/src/sst/core/sync/syncManager.cc
@@ -31,6 +31,7 @@
 #include <atomic>
 #include <cinttypes>
 #include <sys/time.h>
+#include <unistd.h>
 
 namespace SST {
 
@@ -482,7 +483,8 @@ SyncManager::handleInteractiveConsole()
                 if ( ic_state ==  InteractiveConsole::ICretcode::SUMMARY ) { // Print thread info summary
                     for ( uint32_t tindex = 0; tindex < num_ranks_.thread; tindex++ ) {
                         if ( rank_.thread == tindex ) {
-                            std::cout << "Rank:" << rank_.rank << " Thread:" << rank_.thread;
+                            std::cout << "Rank:" << rank_.rank << " Thread:" << rank_.thread
+                                << " (Process:" << getppid() << ") ";
                             // Print component summary
                             if ( sim_->interactive_ != nullptr ) {
                                 sim_->interactive_->summary();

--- a/src/sst/core/sync/syncManager.cc
+++ b/src/sst/core/sync/syncManager.cc
@@ -153,7 +153,7 @@ public:
     void before() override {}
     void after() override {}
     void execute() override {}
-    //void bwait() override {}
+    // void bwait() override {}
     void processLinkUntimedData() override {}
     void finalizeLinkConfigurations() override {}
     void prepareForComplete() override {}
@@ -330,7 +330,7 @@ SyncManager::SyncManager(const RankInfo& rank, const RankInfo& num_ranks, SimTim
 
     setPriority(SYNCPRIORITY);
 
-    //sim_->getSimulationOutput().output("skk:syncmgr:constructor: T%d\n", rank_.thread);
+    // sim_->getSimulationOutput().output("skk:syncmgr:constructor: T%d\n", rank_.thread);
 }
 
 SyncManager::SyncManager()
@@ -371,28 +371,28 @@ SyncManager::exchangeLinkInfo()
 }
 
 void
-SyncManager::handleShutdown() {
+SyncManager::handleShutdown()
+{
 
-    //ic_barrier_.wait(); // SKK This one may not be necessary...
+    // ic_barrier_.wait(); // SKK This one may not be necessary...
 #if 0
         // Check for shutdown
         Output& out = sim_->getSimulationOutput();
         out.output("skk:syncmgr:handleShutdown:Before T%d:endSim=%d, shutdown_mode=%d, enter_shutdown=%d, \n", 
             rank_.thread, sim_->endSim, sim_->shutdown_mode_, sim_->enter_shutdown_);
 #endif
-        // If my thread enter_shutdown_ is true, then set shared enter_shutdown
-        if (sim_->enter_shutdown_ == true) {
-            enter_shutdown_.fetch_or(true);
-            endSim_.fetch_or(true);
-            if (sim_->shutdown_mode_ == true) {
-                shutdown_mode_.store(true);
-            }
+    // If my thread enter_shutdown_ is true, then set shared enter_shutdown
+    if ( sim_->enter_shutdown_ == true ) {
+        enter_shutdown_.fetch_or(true);
+        endSim_.fetch_or(true);
+        if ( sim_->shutdown_mode_ == true ) {
+            shutdown_mode_.store(true);
         }
-        ic_barrier_.wait();
-        if (endSim_ == true) {
-            sim_->setEndSim();
-
-        }
+    }
+    ic_barrier_.wait();
+    if ( endSim_ == true ) {
+        sim_->setEndSim();
+    }
 }
 
 void
@@ -401,14 +401,14 @@ SyncManager::handleInteractiveConsole()
     ic_barrier_.wait(); // SKK This one may not be necessary...
 
     // Handle interactive console
-    if (num_ranks_.thread > 1) {
+    if ( num_ranks_.thread > 1 ) {
 
         // 1) Check enter interactive and set mask if needed (could use mask to show triggers)
-        if (sim_->enter_interactive_ == true) {
+        if ( sim_->enter_interactive_ == true ) {
             unsigned bit = 1UL << rank_.thread;
             enter_interactive_mask_.fetch_or(bit);
         }
-        ic_barrier_.wait();  // Ensure everyone has written the mask before checking
+        ic_barrier_.wait(); // Ensure everyone has written the mask before checking
 
         // If enter interactive set for any thread
         unsigned ic_mask = enter_interactive_mask_.load();
@@ -417,22 +417,21 @@ SyncManager::handleInteractiveConsole()
         out.output("skk:syncmgr:execute: T%d: check enter_interactive_=%d\n", rank_.thread, sim_->enter_interactive_);
         out.output("skk:syncmgr:execute: T%d: enter_interactive_mask_=0x%x\n", rank_.thread, ic_mask);
 #endif
-        if (ic_mask) {
+        if ( ic_mask ) {
             // 2) Print list of threads and whether triggered
-            for (uint32_t tindex = 0; tindex < num_ranks_.thread; tindex++) {
+            for ( uint32_t tindex = 0; tindex < num_ranks_.thread; tindex++ ) {
                 // Actually, not true, we want them to print in order
-                if (rank_.thread == tindex) {
-                    if (rank_.thread == 0)
-                        std::cout << "\nINTERACTIVE CONSOLE\n";
-                    std::cout << "  Rank:" << rank_.rank << "/" << num_ranks_.rank
-                        << " Thread:" << rank_.thread << "/" << num_ranks_.thread;
-                    if (sim_->enter_interactive_) {
+                if ( rank_.thread == tindex ) {
+                    if ( rank_.thread == 0 ) std::cout << "\nINTERACTIVE CONSOLE\n";
+                    std::cout << "  Rank:" << rank_.rank << "/" << num_ranks_.rank << " Thread:" << rank_.thread << "/"
+                              << num_ranks_.thread;
+                    if ( sim_->enter_interactive_ ) {
                         std::cout << " (Triggered)\n";
                     }
                     else {
                         std::cout << " (Not Triggered)\n";
                     }
-#if 0               // Print component summary? - will be at whatever level was last (maybe print PWD instead?)
+#if 0 // Print component summary? - will be at whatever level was last (maybe print PWD instead?)
                     if (sim_->interactive_ != nullptr) {
                         sim_->interactive_->summary();
                     }
@@ -452,21 +451,21 @@ SyncManager::handleInteractiveConsole()
             }
             ic_barrier_.wait();
 #else
-            if (rank_.thread == 0) {
+            if ( rank_.thread == 0 ) {
                 current_ic_thread_.store(0);
             }
-            ic_barrier_.wait();  // Ensure store is complete before everyone checks
+            ic_barrier_.wait(); // Ensure store is complete before everyone checks
 #endif
 
             // 4) Tj: Invoke IC for current thread, with ability to change to new thread
-            unsigned int tid = current_ic_thread_.load();
-            int ic_state = 0;// interactive_state_.load();
-            while (ic_state != -1) {
-                if ((rank_.thread == tid) && (sim_->interactive_ != nullptr)) {
+            unsigned int tid      = current_ic_thread_.load();
+            int          ic_state = 0; // interactive_state_.load();
+            while ( ic_state != -1 ) {
+                if ( (rank_.thread == tid) && (sim_->interactive_ != nullptr) ) {
                     // Invoke IC for the thread
                     int result = sim_->interactive_->execute(sim_->interactive_msg_);
 
-                    if (result >= 0) { // change thread to threadID <result>
+                    if ( result >= 0 ) { // change thread to threadID <result>
                         current_ic_thread_.store(result);
                         current_ic_state_.store(0);
                     }
@@ -475,38 +474,38 @@ SyncManager::handleInteractiveConsole()
                     }
                 }
                 ic_barrier_.wait();
-                handleShutdown();  // Check if console issued shutdown command
-                tid = current_ic_thread_.load();
+                handleShutdown(); // Check if console issued shutdown command
+                tid      = current_ic_thread_.load();
                 ic_state = current_ic_state_.load();
-                //out.output("T%d: tid %d, ic_state %d\n", rank_.thread, tid, ic_state);
-                if (ic_state == -2) {  // Print thread info summary
-                    for (uint32_t tindex = 0; tindex < num_ranks_.thread; tindex++) {
-                        if (rank_.thread == tindex) {
+                // out.output("T%d: tid %d, ic_state %d\n", rank_.thread, tid, ic_state);
+                if ( ic_state == -2 ) { // Print thread info summary
+                    for ( uint32_t tindex = 0; tindex < num_ranks_.thread; tindex++ ) {
+                        if ( rank_.thread == tindex ) {
                             std::cout << "Rank:" << rank_.rank << " Thread:" << rank_.thread;
                             // Print component summary
-                            if (sim_->interactive_ != nullptr) {
+                            if ( sim_->interactive_ != nullptr ) {
                                 sim_->interactive_->summary();
                             }
                         }
                         ic_barrier_.wait();
                     }
                     current_ic_state_.store(0);
-                }  // if state == -2, print thread info summary
+                } // if state == -2, print thread info summary
             }
 
             // 5) When done, clear interactive mask and enter interactive flags for next round
-            if (rank_.thread == 0) {
+            if ( rank_.thread == 0 ) {
                 enter_interactive_mask_.store(0);
             }
             sim_->enter_interactive_ = false;
             ic_barrier_.wait();
             ic_mask = enter_interactive_mask_.load();
-            //out.output("skk:syncmgr:execute: T%d: After: check enter_interactive_=%d\n", rank_.thread, sim_->enter_interactive_);
-            //out.output("skk:syncmgr:execute: T%d: AFter: enter_interactive_mask_=0x%x\n", rank_.thread, ic_mask);   
+            // out.output("skk:syncmgr:execute: T%d: After: check enter_interactive_=%d\n", rank_.thread,
+            // sim_->enter_interactive_); out.output("skk:syncmgr:execute: T%d: AFter: enter_interactive_mask_=0x%x\n",
+            // rank_.thread, ic_mask);
         }
     } // end if num_ranks_.thread > 1: Handle interactive console
       // SKK Serial execution handles this in run so it happens right away
-
 }
 
 void
@@ -520,7 +519,7 @@ SyncManager::execute()
     int  sig_end;
     int  sig_usr;
     int  sig_alrm;
-    
+
 
     SimTime_t next_checkpoint_time = MAX_SIMTIME_T;
 
@@ -568,28 +567,27 @@ SyncManager::execute()
             if ( sig_alrm ) real_time_->performSignal(sig_alrm);
         }
 
-        
+
         // Generate checkpoint if needed
         next_checkpoint_time = checkpoint_->check(getDeliveryTime());
 
-        
+
 #if 1
         // SKK Hmmm, should interactive check be before checkpoint in case it want to generate checkpoint?
         // No it should have already scheduled the checkpoint when the watchpoint was hit
 
-        // Handle interactive console - Not even testable yet...   
+        // Handle interactive console - Not even testable yet...
         // SKK If we had an interactive_action, we could call check()
-        //interactive_action_->check(getDeliveryTime());
+        // interactive_action_->check(getDeliveryTime());
         // Need barrier here
-        if (rank_.thread == 0) {
-            //std::cout << "skk: syncmgr rank: t0: interactive execute\n";
-            if (sim_->enter_interactive_ == true) {
+        if ( rank_.thread == 0 ) {
+            // std::cout << "skk: syncmgr rank: t0: interactive execute\n";
+            if ( sim_->enter_interactive_ == true ) {
                 sim_->enter_interactive_ = false; // IC may schedule IC again
-                if (sim_->interactive_ != nullptr)
-                    sim_->interactive_->execute(sim_->interactive_msg_);
+                if ( sim_->interactive_ != nullptr ) sim_->interactive_->execute(sim_->interactive_msg_);
             }
         }
-        
+
 #endif
 
         // No barrier needed. Either the check failed and no
@@ -611,15 +609,15 @@ SyncManager::execute()
             real_time_->getSignals(sig_end, sig_usr, sig_alrm);
             threadSync_->setSignals(sig_end, sig_usr, sig_alrm);
         }
-        threadSync_->execute();  // exchange event queues
+        threadSync_->execute(); // exchange event queues
 
         // Handle signals for multi-threaded runs/no MPI
         if ( num_ranks_.rank == 1 ) {
             signals_received = threadSync_->getSignals(sig_end, sig_usr, sig_alrm);
 #if 1
             Output& out = sim_->getSimulationOutput();
-            out.output("skk:syncmgr:execute: T%d: sig_end=%d, sig_usr=%d, sig_alrm=%d, received=%d\n", 
-               rank_.thread, sig_end, sig_usr, sig_alrm, signals_received);
+            out.output("skk:syncmgr:execute: T%d: sig_end=%d, sig_usr=%d, sig_alrm=%d, received=%d\n", rank_.thread,
+                sig_end, sig_usr, sig_alrm, signals_received);
 #endif
             if ( sig_end )
                 real_time_->performSignal(sig_end);
@@ -628,7 +626,7 @@ SyncManager::execute()
                 if ( sig_alrm ) real_time_->performSignal(sig_alrm);
             }
             next_checkpoint_time = checkpoint_->check(getDeliveryTime());
-             
+
             handleShutdown();
             handleInteractiveConsole();
 
@@ -642,7 +640,7 @@ SyncManager::execute()
         break;
     default:
         break;
-    }  // end switch
+    } // end switch
     computeNextInsert(next_checkpoint_time);
     RankExecBarrier_[4].wait();
 
@@ -737,12 +735,12 @@ SyncManager::addProfileTool(Profile::SyncProfileTool* tool)
     profile_tools_->addProfileTool(tool);
 }
 
-std::atomic<unsigned> SyncManager::enter_interactive_mask_{ 0 };
-std::atomic<int> SyncManager::current_ic_thread_{0};
-std::atomic<int> SyncManager::current_ic_state_{0};
-std::atomic<unsigned> SyncManager::enter_shutdown_{ 0 };
-std::atomic<unsigned> SyncManager::endSim_{ false };
-std::atomic<unsigned> SyncManager::shutdown_mode_{ false };
+std::atomic<unsigned>     SyncManager::enter_interactive_mask_ { 0 };
+std::atomic<int>          SyncManager::current_ic_thread_ { 0 };
+std::atomic<int>          SyncManager::current_ic_state_ { 0 };
+std::atomic<unsigned>     SyncManager::enter_shutdown_ { 0 };
+std::atomic<unsigned>     SyncManager::endSim_ { false };
+std::atomic<unsigned>     SyncManager::shutdown_mode_ { false };
 Core::ThreadSafe::Barrier SyncManager::ic_barrier_;
 
 

--- a/src/sst/core/sync/syncManager.h
+++ b/src/sst/core/sync/syncManager.h
@@ -146,6 +146,8 @@ public:
     ActivityQueue* registerLink(
         const RankInfo& to_rank, const RankInfo& from_rank, const std::string& name, Link* link);
     void exchangeLinkInfo();
+    void handleShutdown();
+    void handleInteractiveConsole();
     void execute() override;
 
     /** Cause an exchange of Initialization Data to occur */
@@ -188,6 +190,13 @@ private:
 
     RealTimeManager*  real_time_;
     CheckpointAction* checkpoint_;
+    static std::atomic<unsigned> enter_interactive_mask_;
+    static std::atomic<int> current_ic_thread_;
+    static std::atomic<int> current_ic_state_;
+    static std::atomic<unsigned> enter_shutdown_;
+    static std::atomic<unsigned> endSim_;
+    static std::atomic<unsigned> shutdown_mode_;
+    static Core::ThreadSafe::Barrier ic_barrier_;
 
     SyncProfileToolList* profile_tools_ = nullptr;
 

--- a/src/sst/core/watchPoint.cc
+++ b/src/sst/core/watchPoint.cc
@@ -15,8 +15,10 @@
 #include "sst/core/watchPoint.h"
 
 #include "sst/core/output.h"
+#include "sst/core/realtime.h"
 #include "sst/core/simulation_impl.h"
 #include "sst/core/sst_types.h"
+
 
 #include <cstddef>
 #include <cstdint>
@@ -405,7 +407,8 @@ WatchPoint::heartbeat()
 void
 WatchPoint::simulationShutdown()
 {
-    Simulation_impl::getSimulation()->endSimulation();
+    //Simulation_impl::getSimulation()->signalShutdown(false);  // only works for serial mode
+    Simulation_impl::getSimulation()->setShutdown(false);
 }
 
 void

--- a/src/sst/core/watchPoint.cc
+++ b/src/sst/core/watchPoint.cc
@@ -408,7 +408,9 @@ void
 WatchPoint::simulationShutdown()
 {
     //Simulation_impl::getSimulation()->signalShutdown(false);  // only works for serial mode
-    Simulation_impl::getSimulation()->setShutdown(false);
+    Simulation_impl::getSimulation()->signalShutdown(false);
+    std::cout << "wp simulation shutdown\n";
+    //Simulation_impl::getSimulation()->setShutdown(false);
 }
 
 void

--- a/src/sst/core/watchPoint.cc
+++ b/src/sst/core/watchPoint.cc
@@ -19,7 +19,6 @@
 #include "sst/core/simulation_impl.h"
 #include "sst/core/sst_types.h"
 
-
 #include <cstddef>
 #include <cstdint>
 #include <cstdio>
@@ -407,10 +406,10 @@ WatchPoint::heartbeat()
 void
 WatchPoint::simulationShutdown()
 {
-    //Simulation_impl::getSimulation()->signalShutdown(false);  // only works for serial mode
+    // Simulation_impl::getSimulation()->signalShutdown(false);  // only works for serial mode
     Simulation_impl::getSimulation()->signalShutdown(false);
     std::cout << "wp simulation shutdown\n";
-    //Simulation_impl::getSimulation()->setShutdown(false);
+    // Simulation_impl::getSimulation()->setShutdown(false);
 }
 
 void

--- a/src/sst/core/watchPoint.cc
+++ b/src/sst/core/watchPoint.cc
@@ -37,7 +37,8 @@ WatchPoint::InteractiveWPAction::invokeAction(WatchPoint* wp)
     msg("    SetInteractive");
     wp->setEnterInteractive(); // Trigger action
     std::string handlerStr = wp->handlerToString(wp->triggerHandler);
-    wp->setInteractiveMsg(format_string("  WP%ld: %s : %s ...", wp->wpIndex, handlerStr.c_str(), wp->name_.c_str()));
+    wp->setInteractiveMsg(
+        format_string("  Last Trigger: WP%ld: %s : %s ...", wp->wpIndex, handlerStr.c_str(), wp->name_.c_str()));
     // Note that the interactive action is delayed and
     // we want to be able to print the Trace Buffer there.
     // So, resetTraceBuffer for this case is in handlers
@@ -103,37 +104,52 @@ WatchPoint::WatchPoint(size_t index, const std::string& name, Core::Serializatio
 WatchPoint::~WatchPoint() {}
 
 void
+WatchPoint::genericHandler(HANDLER h)
+{
+    if ( tb_ ) {
+
+        if ( reset_ && !getInteractive() ) {
+            tb_->resetTraceBuffer();
+            triggerCount = 0;
+            reset_       = false;
+        }
+
+        SimTime_t cycle = getCurrentSimCycle();
+
+        bool invoke = tb_->sampleT(trigger, cycle, handlerToString(h));
+        if ( trigger == true ) triggerCount++;
+        trigger = false;
+        if ( invoke ) {
+            triggerHandler = h;
+            setBufferReset();
+            wpAction->invokeAction(this);
+            triggerHandler = HANDLER::NONE;
+        }
+    }
+    else {
+        msg("    No trace buffer");
+        if ( reset_ && !getInteractive() ) {
+            triggerCount = 0;
+            reset_       = false;
+        }
+        if ( trigger ) {
+            triggerHandler = h;
+            triggerCount++;
+            reset_ = true;
+            wpAction->invokeAction(this);
+            trigger        = false;
+            triggerHandler = HANDLER::NONE;
+        }
+    }
+}
+
+void
 WatchPoint::beforeHandler(uintptr_t UNUSED(key), const Event* UNUSED(ev))
 {
     if ( handler & BEFORE_EVENT ) {
         msg("  Before Event Handler");
         check();
-        if ( tb_ ) {
-
-            if ( reset_ && !getInteractive() ) {
-                tb_->resetTraceBuffer();
-                reset_ = false;
-            }
-
-            SimTime_t cycle  = getCurrentSimCycle();
-            bool      invoke = tb_->sampleT(trigger, cycle, "BE");
-            trigger          = false;
-            if ( invoke ) {
-                triggerHandler = HANDLER::BEFORE_EVENT;
-                setBufferReset();
-                wpAction->invokeAction(this);
-                triggerHandler = HANDLER::NONE;
-            }
-        }
-        else {
-            msg("    No trace buffer");
-            if ( trigger ) {
-                triggerHandler = HANDLER::BEFORE_EVENT;
-                wpAction->invokeAction(this);
-                trigger        = false;
-                triggerHandler = HANDLER::NONE;
-            }
-        }
+        genericHandler(HANDLER::BEFORE_EVENT);
     } // if BEFORE_EVENT
 }
 
@@ -143,32 +159,7 @@ WatchPoint::afterHandler(uintptr_t UNUSED(key))
     if ( handler & AFTER_EVENT ) {
         msg("  After Event Handler");
         check();
-        if ( tb_ ) {
-
-            if ( reset_ && !getInteractive() ) {
-                tb_->resetTraceBuffer();
-                reset_ = false;
-            }
-
-            SimTime_t cycle  = getCurrentSimCycle();
-            bool      invoke = tb_->sampleT(trigger, cycle, "AE");
-            trigger          = false;
-            if ( invoke ) {
-                triggerHandler = HANDLER::AFTER_EVENT;
-                setBufferReset();
-                wpAction->invokeAction(this);
-                triggerHandler = HANDLER::NONE;
-            }
-        }
-        else {
-            msg("    No trace buffer");
-            if ( trigger ) {
-                triggerHandler = HANDLER::AFTER_EVENT;
-                wpAction->invokeAction(this);
-                trigger        = false;
-                triggerHandler = HANDLER::NONE;
-            }
-        }
+        genericHandler(HANDLER::AFTER_EVENT);
     } // if AFTER_EVENT
 }
 
@@ -178,31 +169,7 @@ WatchPoint::beforeHandler(uintptr_t UNUSED(key), const Cycle_t& UNUSED(cycle))
     if ( handler & BEFORE_CLOCK ) {
         msg("  Before Clock Handler");
         check();
-        if ( tb_ ) {
-            if ( reset_ && !getInteractive() ) {
-                tb_->resetTraceBuffer();
-                reset_ = false;
-            }
-
-            SimTime_t cycle  = getCurrentSimCycle();
-            bool      invoke = tb_->sampleT(trigger, cycle, "BC");
-            trigger          = false;
-            if ( invoke ) {
-                triggerHandler = HANDLER::BEFORE_CLOCK;
-                setBufferReset();
-                wpAction->invokeAction(this);
-                triggerHandler = HANDLER::NONE;
-            }
-        }
-        else {
-            msg("    No trace buffer");
-            if ( trigger ) {
-                triggerHandler = HANDLER::BEFORE_CLOCK;
-                wpAction->invokeAction(this);
-                trigger        = false;
-                triggerHandler = HANDLER::NONE;
-            }
-        }
+        genericHandler(HANDLER::BEFORE_CLOCK);
     } // if AFTER_CLOCK
 }
 
@@ -212,31 +179,7 @@ WatchPoint::afterHandler(uintptr_t UNUSED(key), const bool& UNUSED(ret))
     if ( handler & AFTER_CLOCK ) {
         msg("  After Clock Handler");
         check();
-        if ( tb_ ) {
-            if ( reset_ && !getInteractive() ) {
-                tb_->resetTraceBuffer();
-                reset_ = false;
-            }
-
-            SimTime_t cycle  = getCurrentSimCycle();
-            bool      invoke = tb_->sampleT(trigger, cycle, "AC");
-            trigger          = false;
-            if ( invoke ) {
-                triggerHandler = HANDLER::AFTER_CLOCK;
-                setBufferReset();
-                wpAction->invokeAction(this);
-                triggerHandler = HANDLER::NONE;
-            }
-        }
-        else {
-            msg("    No trace buffer");
-            if ( trigger ) {
-                triggerHandler = HANDLER::AFTER_CLOCK;
-                wpAction->invokeAction(this);
-                trigger        = false;
-                triggerHandler = HANDLER::NONE;
-            }
-        }
+        genericHandler(HANDLER::AFTER_CLOCK);
     } // if AFTER_CLOCK
 }
 
@@ -263,6 +206,7 @@ void
 WatchPoint::printTrace()
 {
     if ( tb_ != nullptr ) {
+        std::cout << "TriggerCount=" << triggerCount << std::endl;
         tb_->dumpTriggerRecord();
         tb_->dumpTraceBufferT();
     }
@@ -329,6 +273,8 @@ WatchPoint::printHandler()
 void
 WatchPoint::printWatchpoint()
 {
+
+    std::cout << "TriggerCount " << triggerCount << " : ";
     printHandler();
     // TODO: print the logic values
     for ( size_t i = 0; i < numCmpObj_; i++ ) { // Print trigger tests
@@ -341,6 +287,7 @@ WatchPoint::printWatchpoint()
         std::cout << " : ";
     }
     printAction();
+
     std::cout << std::endl;
 }
 

--- a/src/sst/core/watchPoint.cc
+++ b/src/sst/core/watchPoint.cc
@@ -353,10 +353,8 @@ WatchPoint::heartbeat()
 void
 WatchPoint::simulationShutdown()
 {
-    // Simulation_impl::getSimulation()->signalShutdown(false);  // only works for serial mode
     Simulation_impl::getSimulation()->signalShutdown(false);
     std::cout << "wp simulation shutdown\n";
-    // Simulation_impl::getSimulation()->setShutdown(false);
 }
 
 void

--- a/src/sst/core/watchPoint.h
+++ b/src/sst/core/watchPoint.h
@@ -168,6 +168,7 @@ public:
     void        setHandler(unsigned handlerType);
     std::string handlerToString(HANDLER h);
     void        printHandler();
+    void        genericHandler(HANDLER h);
     void        printWatchpoint();
     void        resetTraceBuffer();
     inline bool checkReset() { return reset_; }
@@ -204,8 +205,10 @@ private:
     HANDLER                                                handler        = ALL;
     bool                                                   trigger        = false;
     HANDLER                                                triggerHandler = HANDLER::NONE;
+    size_t                                                 triggerCount   = 0;
     bool                                                   reset_         = false;
     WPAction*                                              wpAction;
+
 
     void     setBufferReset();
     void     check();


### PR DESCRIPTION
Initial support for single-rank, multithreaded interactive debug console.  
Breaks into console during synchronization with the syncManager handleInteractiveConsole() function handling invoking the interactive console for different threads. By default, it starts in thread 0. The sync manager decides which action to take based on the return code from the interactive console:
- Positive number: Represents a threadID and the syncManager invokes the interactive console on the specified thread.
- DONE (-1): interactive console is done and simulation can resume
- SUMMARY (-2): Prints a summary of the rank, thread, process IDs for each thread and whether they were triggered during simulation

The synchManager handleShutdown() function handles checking for shutdown from the interactive console shutdown command or shutdown action. It must check for shutdown both at the beginning of the synchronization (e.g. a shutdown action was triggered during run) and after the interactive console has completed (e.g. the shutdown command was issued). 

Two new interactive console commands are added to the interactive console to support multiple threads. The info command reports thread rank ID, thread ID, and process ID for either the current thread (“info current”) or all threads (“info all”). Note that the info for the current thread is handled within the thread. However, the info for all the threads returns control to the syncManager which calls the “summary” function for each thread, before returning interactive console control back to the original thread. 

The watchpoint triggers were also modified to count the number of times a watchpoint triggers and, for trace, the last watchpoint trigger record. 

Finally there is some code clean up and a fix for recursive print, which would sometimes cause a seg fault.  

Test with the sst-ext-tests/multithread_ic branch. 
