### PR TITLE
provides EOF functionality for CTL-D when command line is empty

### DIFF
--- a/src/sst/core/impl/interactive/cmdLineEditor.cc
+++ b/src/sst/core/impl/interactive/cmdLineEditor.cc
@@ -239,6 +239,9 @@ CmdLineEditor::getline(const std::vector<std::string>& cmdHistory, std::string& 
     writeStr(prompt_line.str());
     curpos = history[index].size() + prompt.size() + 1;
 
+    // EOF
+    bool end_of_file = false;
+
     // Start checking for keys
     char              c;
     int               bytesRead = 1;
@@ -313,11 +316,16 @@ CmdLineEditor::getline(const std::vector<std::string>& cmdHistory, std::string& 
             redraw_line(history[index]);
         }
         else if ( c == ctrl_d ) {
-            // delete character at cursor
-            int position = curpos - prompt.size() - 1;
-            if ( position < 0 || position >= (int)history[index].size() ) {
-                continue;
+           int position = curpos - prompt.size() - 1;
+            if (position == 0 && history[index].size() == 0 ) {
+                // if the line is empty then quit (tactcomplabs/sst-core #32)
+                end_of_file = true;
+                break;
             }
+            if ( position < 0 || position >= (int)history[index].size() ) {
+                continue; // Something went wrong
+            }
+            // delete the next character
             history[index].erase(position, 1);
             redraw_line(history[index]);
         }
@@ -371,6 +379,10 @@ CmdLineEditor::getline(const std::vector<std::string>& cmdHistory, std::string& 
     this->restoreTermMode();
 
     // set the new line info
-    newcmd = history[index];
+    if (end_of_file)
+        newcmd = "quit";
+    else 
+        newcmd = history[index];
+
     writeStr("\n");
 }


### PR DESCRIPTION
This fixes #32 

We should now support the following behavior with CTRL-D
```
       end-of-file (usually C-d)
              The  character indicating end-of-file as set, for example, by ``stty''.  If this character is
              read when there are no characters on the line, and point is at the  beginning  of  the  line,
              Readline interprets it as the end of input and returns EOF.
       delete-char (C-d)
              Delete  the  character  at point.  If this function is bound to the same character as the tty
              EOF character, as C-d commonly is, see above for the effects.
```

@skuntz I don't have a way to add a test for this. Appreciate if you can kick the tires on it.

As an aside, I'm wondering if we want to add another prompt for 'are you sure you want to quit' or 'are you sure you want to shutdown'. That's a separate issue though