### PR TITLE
Multithreaded iconsole - support for shared replay, logging, autocomplete, and confirm commands

### DIFF
--- a/src/sst/core/checkpointAction.cc
+++ b/src/sst/core/checkpointAction.cc
@@ -217,7 +217,7 @@ CheckpointAction::createCheckpoint(Simulation_impl* sim)
         if ( r == rank_.rank ) {
             // If this is my rank go ahead
             for ( uint32_t t = 0; t < num_ranks.thread; ++t ) {
-                
+
                 // If this is my thread go ahead
                 if ( t == rank_.thread ) {
                     sim->checkpoint_append_registry(directory + "/" + registry_name, filename);
@@ -256,7 +256,7 @@ CheckpointAction::createCheckpoint(Simulation_impl* sim)
 // SyncManager check whether a checkpoint needs to be generated
 SimTime_t
 CheckpointAction::check(SimTime_t current_time)
-{ 
+{
 #if 0
     Simulation_impl* sim = Simulation_impl::getSimulation();
     sim->getSimulationOutput().output(
@@ -267,7 +267,7 @@ CheckpointAction::check(SimTime_t current_time)
     // initiated.  This will also handle the case where both a sim and
     // real-time trigger happened at the same time
     if ( (current_time == next_sim_time_) || generate_ ) {
-        Simulation_impl* sim = Simulation_impl::getSimulation();  
+        Simulation_impl* sim = Simulation_impl::getSimulation();
         createCheckpoint(sim);
         generate_ = false;
         // Only add to the simulation-interval checkpoint time if it

--- a/src/sst/core/impl/interactive/simpleDebug.cc
+++ b/src/sst/core/impl/interactive/simpleDebug.cc
@@ -32,12 +32,12 @@ namespace SST::IMPL::Interactive {
 
 // Static Initialization
 bool          SimpleDebugger::autoCompleteEnable = true;
-std::ofstream SimpleDebugger::loggingFile; 
+std::ofstream SimpleDebugger::loggingFile;
 std::ifstream SimpleDebugger::replayFile;
 std::string   SimpleDebugger::loggingFilePath = "sst-console.out";
-std::string   SimpleDebugger::replayFilePath = "sst-console.in";
-bool          SimpleDebugger::enLogging = false;
-bool          SimpleDebugger::confirm = true;
+std::string   SimpleDebugger::replayFilePath  = "sst-console.in";
+bool          SimpleDebugger::enLogging       = false;
+bool          SimpleDebugger::confirm         = true;
 SimpleDebugger::SimpleDebugger(Params& params) :
     InteractiveConsole()
 {
@@ -267,7 +267,7 @@ SimpleDebugger::execute(const std::string& msg)
     // Descend into the name_stack
     cd_name_stack();
 
-    done = false;
+    done     = false;
     retState = DONE;
 
     // Select the input source and next command line
@@ -788,29 +788,30 @@ SimpleDebugger::cmd_print(std::vector<std::string>& tokens)
     int         recurse = 4; // default -r depth
     std::string tok     = tokens[1];
     if ( (tok.size() >= 2) && (tok[0] == '-') && (tok[1] == 'r') ) {
-      // Got a -r
-      std::string num = tok.substr(2);
-      if ( num.size() != 0 ) {
-	try {
-	  recurse = SST::Core::from_string<int>(num);
-	}
-	catch ( const std::invalid_argument& e ) {
-	  printf("Invalid number format specified with -r: %s\n", tok.c_str());
-	  return false;
-	}
-      } else {
-	std::string num = tok.substr(2);
-	if ( num.size() != 0 ) {
-	  try {
-	    recurse = SST::Core::from_string<int>(num);
-	  }
-	  catch ( std::invalid_argument& e ) {
-	    printf("Invalid number format specified with -r: %s\n", tok.c_str());
-	    return false;
-	  }
-	}
-      }
-      var_index = 2;
+        // Got a -r
+        std::string num = tok.substr(2);
+        if ( num.size() != 0 ) {
+            try {
+                recurse = SST::Core::from_string<int>(num);
+            }
+            catch ( const std::invalid_argument& e ) {
+                printf("Invalid number format specified with -r: %s\n", tok.c_str());
+                return false;
+            }
+        }
+        else {
+            std::string num = tok.substr(2);
+            if ( num.size() != 0 ) {
+                try {
+                    recurse = SST::Core::from_string<int>(num);
+                }
+                catch ( std::invalid_argument& e ) {
+                    printf("Invalid number format specified with -r: %s\n", tok.c_str());
+                    return false;
+                }
+            }
+        }
+        var_index = 2;
     }
 
     if ( tokens.size() == var_index ) {
@@ -1306,8 +1307,7 @@ SimpleDebugger::cmd_define(std::vector<std::string>& UNUSED(tokens))
     }
 
     // Create a user command entry (or clear existing one)
-    if ( cmdRegistry.beginUserCommand(tokens[1]) )
-        line_entry_mode = LINE_ENTRY_MODE::DEFINE;
+    if ( cmdRegistry.beginUserCommand(tokens[1]) ) line_entry_mode = LINE_ENTRY_MODE::DEFINE;
 
     return true;
 }
@@ -1319,8 +1319,7 @@ SimpleDebugger::cmd_document(std::vector<std::string>& tokens)
         std::cout << "Invalid\nsyntax: document <cmd_name>" << std::endl;
         return false;
     }
-    if ( cmdRegistry.beginDocCommand(tokens[1]) ) 
-        line_entry_mode = LINE_ENTRY_MODE::DOCUMENT;
+    if ( cmdRegistry.beginDocCommand(tokens[1]) ) line_entry_mode = LINE_ENTRY_MODE::DOCUMENT;
 
     return true;
 }

--- a/src/sst/core/impl/interactive/simpleDebug.cc
+++ b/src/sst/core/impl/interactive/simpleDebug.cc
@@ -30,6 +30,14 @@
 
 namespace SST::IMPL::Interactive {
 
+// Static Initialization
+bool          SimpleDebugger::autoCompleteEnable = true;
+std::ofstream SimpleDebugger::loggingFile; 
+std::ifstream SimpleDebugger::replayFile;
+std::string   SimpleDebugger::loggingFilePath = "sst-console.out";
+std::string   SimpleDebugger::replayFilePath = "sst-console.in";
+bool          SimpleDebugger::enLogging = false;
+bool          SimpleDebugger::confirm = true;
 SimpleDebugger::SimpleDebugger(Params& params) :
     InteractiveConsole()
 {
@@ -240,6 +248,7 @@ SimpleDebugger::summary()
             std::cout << x.first.c_str() << "/ (" << x.second->getType() << ")\n";
         }
     }
+    std::cout << std::endl;
 #endif
 }
 
@@ -1255,8 +1264,9 @@ getLogicOpFromString(const std::string& opStr)
 bool
 SimpleDebugger::cmd_watchlist(std::vector<std::string>& UNUSED(tokens))
 {
+    RankInfo info = getRank();
     // Print the watch points
-    printf("Current watch points:\n");
+    printf("R%d,T%d: Current watch points:\n", info.rank, info.thread);
     int count = 0;
     for ( auto& x : watch_points_ ) {
         // printf("  %d - %s\n", count++, x.first->getName().c_str());

--- a/src/sst/core/impl/interactive/simpleDebug.h
+++ b/src/sst/core/impl/interactive/simpleDebug.h
@@ -18,15 +18,20 @@
 #include "sst/core/serialization/objectMapDeferred.h"
 #include "sst/core/watchPoint.h"
 
+#include <atomic>
+#include <cassert>
 #include <cstddef>
 #include <cstdint>
 #include <deque>
 #include <fstream>
 #include <functional>
+#include <iostream>
 #include <list>
 #include <map>
 #include <ostream>
+#include <queue>
 #include <sstream>
+#include <stack>
 #include <string>
 #include <utility>
 #include <vector>

--- a/src/sst/core/impl/interactive/simpleDebug.h
+++ b/src/sst/core/impl/interactive/simpleDebug.h
@@ -270,17 +270,17 @@ private:
     void save_name_stack();
     void cd_name_stack();
 
-    bool autoCompleteEnable = true;
+    static bool autoCompleteEnable; //skk = true;
 
     // gdb/lldb thread spin support
     uint64_t spinner = 1;
 
     // logging support
-    std::ofstream loggingFile;
-    std::ifstream replayFile;
-    std::string   loggingFilePath = "sst-console.out";
-    std::string   replayFilePath  = "sst-console.in";
-    bool          enLogging       = false;
+    static std::ofstream loggingFile;
+    static std::ifstream replayFile;
+    static std::string   loggingFilePath; //skk = "sst-console.out";
+    static std::string   replayFilePath; //skk = "sst-console.in";
+    static bool          enLogging; //skk = false;
 
     // command injection (for sst --replay option)
     std::stringstream injectedCommand;
@@ -295,7 +295,7 @@ private:
     // Keep track of all the WatchPoints
     std::vector<std::pair<WatchPoint*, BaseComponent*>> watch_points_;
     bool                                                clear_watchlist();
-    bool                                                confirm = true; // Ask for confirmation to clear watchlist
+    static bool                                         confirm;//skk = true; // Ask for confirmation to clear watchlist
 
     std::vector<std::string> tokenize(std::vector<std::string>& tokens, const std::string& input);
 

--- a/src/sst/core/impl/interactive/simpleDebug.h
+++ b/src/sst/core/impl/interactive/simpleDebug.h
@@ -84,10 +84,10 @@ public:
         group_(ConsoleCommandGroup::USER)
     {}
     ConsoleCommand() {}; // default constructor
-    const std::string& str_long() const { return str_long_; }
-    const std::string& str_short() const { return str_short_; }
-    const std::string& str_help() const { return str_help_; }
-    void               setUserHelp(std::string& help) { str_help_ = help; }
+    const std::string&         str_long() const { return str_long_; }
+    const std::string&         str_short() const { return str_short_; }
+    const std::string&         str_help() const { return str_help_; }
+    void                       setUserHelp(std::string& help) { str_help_ = help; }
     const ConsoleCommandGroup& group() const { return group_; }
     // Command Execution
     bool                       exec(std::vector<std::string>& tokens) { return func_(tokens); }
@@ -275,7 +275,7 @@ private:
     void save_name_stack();
     void cd_name_stack();
 
-    static bool autoCompleteEnable; //skk = true;
+    static bool autoCompleteEnable; // skk = true;
 
     // gdb/lldb thread spin support
     uint64_t spinner = 1;
@@ -283,9 +283,9 @@ private:
     // logging support
     static std::ofstream loggingFile;
     static std::ifstream replayFile;
-    static std::string   loggingFilePath; //skk = "sst-console.out";
-    static std::string   replayFilePath; //skk = "sst-console.in";
-    static bool          enLogging; //skk = false;
+    static std::string   loggingFilePath; // skk = "sst-console.out";
+    static std::string   replayFilePath;  // skk = "sst-console.in";
+    static bool          enLogging;       // skk = false;
 
     // command injection (for sst --replay option)
     std::stringstream injectedCommand;
@@ -300,7 +300,7 @@ private:
     // Keep track of all the WatchPoints
     std::vector<std::pair<WatchPoint*, BaseComponent*>> watch_points_;
     bool                                                clear_watchlist();
-    static bool                                         confirm;//skk = true; // Ask for confirmation to clear watchlist
+    static bool confirm; // skk = true; // Ask for confirmation to clear watchlist
 
     std::vector<std::string> tokenize(std::vector<std::string>& tokens, const std::string& input);
 

--- a/src/sst/core/sync/syncManager.cc
+++ b/src/sst/core/sync/syncManager.cc
@@ -621,20 +621,20 @@ SyncManager::execute()
 #if 0
                 if ( sig_alrm ) real_time_->performSignal(sig_alrm);
 #else
-                if (sig_alrm) {
-                    //out.output("skk:syncmgr:execute: T%d: in sigalrm\n", rank_.thread);
+                if ( sig_alrm ) {
+                    // out.output("skk:syncmgr:execute: T%d: in sigalrm\n", rank_.thread);
                     real_time_->performSignal(sig_alrm);
                 }
 #endif
             }
 
-            // Check local checkpoint generate flag and set shared generate if needed. 
-            if (checkpoint_->getCheckpoint() == true) {
+            // Check local checkpoint generate flag and set shared generate if needed.
+            if ( checkpoint_->getCheckpoint() == true ) {
                 ckpt_generate_.store(1);
             }
             // Ensure everyone has written the mask before updating local generate_
-            ic_barrier_.wait();  
-            if (ckpt_generate_.load()) {
+            ic_barrier_.wait();
+            if ( ckpt_generate_.load() ) {
                 checkpoint_->setCheckpoint();
             }
             next_checkpoint_time = checkpoint_->check(getDeliveryTime());


### PR DESCRIPTION
Provides an interim fix for shared replay, logging, autocomplete, and confirm functionality for the single-rank, multithreaded interactive console.  Some restructuring will be needed when moving to multi-rank support. 

@kpgriesser The restart-sigalrm-NEW test fails periodically, but you noted you have a separate fix for that. 
