### PR TITLE
user prompting to select a variable name for multiple matches

### DIFF
--- a/src/sst/core/impl/interactive/simpleDebug.cc
+++ b/src/sst/core/impl/interactive/simpleDebug.cc
@@ -31,13 +31,14 @@
 namespace SST::IMPL::Interactive {
 
 // Static Initialization
+//TODO kg is there a naming convention for static vars?
 bool          SimpleDebugger::autoCompleteEnable = true;
 std::ofstream SimpleDebugger::loggingFile;
 std::ifstream SimpleDebugger::replayFile;
 std::string   SimpleDebugger::loggingFilePath = "sst-console.out";
 std::string   SimpleDebugger::replayFilePath  = "sst-console.in";
 bool          SimpleDebugger::enLogging       = false;
-bool          SimpleDebugger::confirm         = true;
+bool          SimpleDebugger::confirm_        = true;
 SimpleDebugger::SimpleDebugger(Params& params) :
     InteractiveConsole()
 {
@@ -736,7 +737,7 @@ SimpleDebugger::cmd_cd(std::vector<std::string>& tokens)
     }
 
     bool                                 loop_detected = false;
-    SST::Core::Serialization::ObjectMap* new_obj       = obj_->selectVariable(selection, loop_detected);
+    SST::Core::Serialization::ObjectMap* new_obj       = obj_->selectVariable(selection, loop_detected, confirm_);
     if ( !new_obj || (new_obj == obj_) ) {
         printf("Unknown object in cd command: %s\n", selection.c_str());
         return false;
@@ -1607,15 +1608,15 @@ SimpleDebugger::cmd_setConfirm(std::vector<std::string>& tokens)
     }
 
     if ( (tokens[1] == "true") || (tokens[1] == "t") || (tokens[1] == "T") || (tokens[1] == "1") ) {
-        confirm = true;
+        confirm_ = true;
         return true;
     }
     else if ( (tokens[1] == "false") || (tokens[1] == "f") || (tokens[1] == "F") || (tokens[1] == "0") ) {
-        confirm = false;
+        confirm_ = false;
         return true;
     }
 
-    std::cout << "Invalid argument for confirm: must be true or false" << tokens[1] << std::endl;
+    std::cout << "Invalid argument for confirm: must be true or false. <" << tokens[1] << ">" << std::endl;
     return false;
 }
 
@@ -1623,7 +1624,7 @@ bool
 SimpleDebugger::clear_watchlist()
 {
 
-    if ( confirm ) {
+    if ( confirm_ ) {
         std::string line;
         std::cout << "Do you want to delete all watchpoints? [yes, no]\n";
         std::getline(std::cin, line);

--- a/src/sst/core/impl/interactive/simpleDebug.h
+++ b/src/sst/core/impl/interactive/simpleDebug.h
@@ -297,7 +297,7 @@ private:
     // Keep track of all the WatchPoints
     std::vector<std::pair<WatchPoint*, BaseComponent*>> watch_points_;
     bool                                                clear_watchlist();
-    static bool confirm; // skk = true; // Ask for confirmation to clear watchlist
+    static bool confirm_; // skk = true; // Ask for confirmation to clear watchlist
 
     std::vector<std::string> tokenize(std::vector<std::string>& tokens, const std::string& input);
 

--- a/src/sst/core/serialization/objectMap.cc
+++ b/src/sst/core/serialization/objectMap.cc
@@ -47,12 +47,12 @@ ObjectMap::selectParent()
 }
 
 ObjectMap*
-ObjectMap::selectVariable(std::string name, bool& loop_detected)
+ObjectMap::selectVariable(std::string name, bool& loop_detected, bool confirm)
 {
     // kg maybe there is a way we can go through this to detect problems
     //    before changing objmap state to avoid memory corruption bugs.
     loop_detected  = false;
-    ObjectMap* var = findVariable(name);
+    ObjectMap* var = findVariable(name, confirm);
 
     // TODO Would prefer this be a simple nullptr to avoid confusion (bugs)
     //  If we get nullptr back, then it didn't exist.  Just return this


### PR DESCRIPTION
The original prototype for `ObjectMap::findVariable` does not handle the case when multiple matches are found.  With this change, the user (by default) will be prompted.  This can be disabled using "confirm false" in the console which will revert to the prototype functionality of simply selecting the first match. 

This edit should be removed by ensuring the object map has unique variable names ( and not use std::multimap )... presumably.  Additionally, the `confirm` information will only be passed into the `cd_cmd`  function so all other calls to `findVariable` may result in prompting the user.  This is by design, as I am hoping we can uniquely the variable names and avoid the use of `std::multimap` altogether. 

Duplicate names can occur at the same level of hierarchy when using sub-components. The one example I know if is creating a variable in a subcomponent name that has the same name as the subcomponent slot it populates. See example in https://github.com/tactcomplabs/sst-ext-tests/pull/99


