### PR TITLE
Add support for paging of output and max line length in interactive mode

### DIFF
--- a/src/sst/core/impl/interactive/Makefile.inc
+++ b/src/sst/core/impl/interactive/Makefile.inc
@@ -10,3 +10,4 @@ sst_core_sources += \
 	impl/interactive/cmdLineEditor.h \
 	impl/interactive/debugStream.h  \
 	impl/interactive/debugStream.cc 
+	

--- a/src/sst/core/impl/interactive/Makefile.inc
+++ b/src/sst/core/impl/interactive/Makefile.inc
@@ -7,5 +7,7 @@ sst_core_sources += \
 	impl/interactive/simpleDebug.cc \
 	impl/interactive/simpleDebug.h \
 	impl/interactive/cmdLineEditor.cc \
-	impl/interactive/cmdLineEditor.h
+	impl/interactive/cmdLineEditor.h \
+	impl/interactive/debugStream.h  \
+	impl/interactive/debugStream.cc 
 

--- a/src/sst/core/impl/interactive/Makefile.inc
+++ b/src/sst/core/impl/interactive/Makefile.inc
@@ -10,4 +10,3 @@ sst_core_sources += \
 	impl/interactive/cmdLineEditor.h \
 	impl/interactive/debugStream.h  \
 	impl/interactive/debugStream.cc 
-

--- a/src/sst/core/impl/interactive/debugStream.cc
+++ b/src/sst/core/impl/interactive/debugStream.cc
@@ -1,47 +1,56 @@
 
 #include "sst/core/impl/interactive/debugStream.h"
+
 #include <iostream>
 
 namespace SST::IMPL::Interactive {
 
-std::streambuf::int_type DebuggerStreamBuf::overflow(std::streambuf::int_type c) {
-        if(quit_){
-            return EOF;
-        }
+std::streambuf::int_type
+DebuggerStreamBuf::overflow(std::streambuf::int_type c)
+{
+    if ( quit_ ) {
+        return EOF;
+    }
 
-        curChars_++;
-        if('\n' == c){
-            curLines_++;
-            curChars_=0;
-            if(paginate_ && (curLines_ % linesPerScreen_ == 0)){
-                dest_->sputc('\n');
-                dest_->pubsync();
-                std::cout << "--Type <RET> for more, q to quit, c to continue without paging--" << std::endl;
-                char cmd = std::cin.get();
-                if(('q' == cmd) || ('Q' == cmd)){
-                    quit_ = true;
-                    std::cin.ignore(1000, '\n');
-                    return EOF;
-                }else if( ('c' == cmd ) || ('C' == cmd)){
-                    paginate_ = false;
-                    std::cin.ignore(1000, '\n');
-                }else{
-                    if('\n' != cmd) std::cin.ignore(1000, '\n');
-                }
-                return c;
+    curChars_++;
+    if ( '\n' == c ) {
+        curLines_++;
+        curChars_ = 0;
+        if ( paginate_ && (curLines_ % linesPerScreen_ == 0) ) {
+            dest_->sputc('\n');
+            dest_->pubsync();
+            std::cout << "--Type <RET> for more, q to quit, c to continue without paging--" << std::endl;
+            char cmd = std::cin.get();
+            if ( ('q' == cmd) || ('Q' == cmd) ) {
+                quit_ = true;
+                std::cin.ignore(1000, '\n');
+                return EOF;
             }
-        } else if( curChars_ == charsPerLine_){
-            dest_->sputc('.');
-            dest_->sputc('.');
-            return dest_->sputc('.');
-        }else if( curChars_ > charsPerLine_){
+            else if ( ('c' == cmd) || ('C' == cmd) ) {
+                paginate_ = false;
+                std::cin.ignore(1000, '\n');
+            }
+            else {
+                if ( '\n' != cmd ) std::cin.ignore(1000, '\n');
+            }
             return c;
         }
-        return dest_->sputc(c);
     }
-
-    int DebuggerStreamBuf::sync() {
-        return dest_->pubsync();
+    else if ( curChars_ == charsPerLine_ ) {
+        dest_->sputc('.');
+        dest_->sputc('.');
+        return dest_->sputc('.');
     }
-
+    else if ( curChars_ > charsPerLine_ ) {
+        return c;
+    }
+    return dest_->sputc(c);
 }
+
+int
+DebuggerStreamBuf::sync()
+{
+    return dest_->pubsync();
+}
+
+} // namespace SST::IMPL::Interactive

--- a/src/sst/core/impl/interactive/debugStream.cc
+++ b/src/sst/core/impl/interactive/debugStream.cc
@@ -1,0 +1,47 @@
+
+#include "sst/core/impl/interactive/debugStream.h"
+#include <iostream>
+
+namespace SST::IMPL::Interactive {
+
+std::streambuf::int_type DebuggerStreamBuf::overflow(std::streambuf::int_type c) {
+        if(quit_){
+            return EOF;
+        }
+
+        curChars_++;
+        if('\n' == c){
+            curLines_++;
+            curChars_=0;
+            if(paginate_ && (curLines_ % linesPerScreen_ == 0)){
+                dest_->sputc('\n');
+                dest_->pubsync();
+                std::cout << "--Type <RET> for more, q to quit, c to continue without paging--" << std::endl;
+                char cmd = std::cin.get();
+                if(('q' == cmd) || ('Q' == cmd)){
+                    quit_ = true;
+                    std::cin.ignore(1000, '\n');
+                    return EOF;
+                }else if( ('c' == cmd ) || ('C' == cmd)){
+                    paginate_ = false;
+                    std::cin.ignore(1000, '\n');
+                }else{
+                    if('\n' != cmd) std::cin.ignore(1000, '\n');
+                }
+                return c;
+            }
+        } else if( curChars_ == charsPerLine_){
+            dest_->sputc('.');
+            dest_->sputc('.');
+            return dest_->sputc('.');
+        }else if( curChars_ > charsPerLine_){
+            return c;
+        }
+        return dest_->sputc(c);
+    }
+
+    int DebuggerStreamBuf::sync() {
+        return dest_->pubsync();
+    }
+
+}

--- a/src/sst/core/impl/interactive/debugStream.h
+++ b/src/sst/core/impl/interactive/debugStream.h
@@ -1,0 +1,85 @@
+// Copyright 2009-2025 NTESS. Under the terms
+// of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2025, NTESS
+// All rights reserved.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+
+#ifndef SST_CORE_IMPL_INTERACTIVE_DEBUGSTREAM_H
+#define SST_CORE_IMPL_INTERACTIVE_DEBUGSTREAM_H
+
+#include <cstddef>
+#include <cstdint>
+#include <ostream>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace SST::IMPL::Interactive {
+
+class DebuggerStreamBuf : public std::streambuf {
+    private:
+    std::streambuf* dest_;
+    unsigned        linesPerScreen_;
+    unsigned        curLines_;
+    bool            paginate_;
+    bool            quit_;
+    unsigned        charsPerLine_;
+    unsigned        curChars_;
+
+    protected:
+    virtual int_type overflow(int_type c) override;
+    virtual int sync() override;
+
+
+    public:
+    DebuggerStreamBuf(std::streambuf* dest, unsigned linesPerScreen, unsigned charsPerLine) 
+        : dest_(dest), linesPerScreen_(linesPerScreen), curLines_(0),
+          paginate_(true), quit_(false), charsPerLine_(charsPerLine), curChars_(0) {}
+
+    void reset(){
+            paginate_ = true;
+            quit_     = false;
+            curLines_ = 0;
+            curChars_ = 0;
+    }
+    void setLineWidth(const unsigned w){charsPerLine_ = w;}
+
+};
+
+class DebuggerStream : public std::ostream {
+    private:
+    DebuggerStreamBuf buf_;
+
+    public:
+    DebuggerStream(std::ostream& dest, unsigned linesPerScreen, unsigned charsPerLine)
+        : std::ostream(&buf_), buf_(dest.rdbuf(), linesPerScreen, charsPerLine) {}
+
+    void reset(){
+        buf_.reset();
+        clear();
+    }
+
+    void setLineWidth(const unsigned w){ buf_.setLineWidth(w);}
+
+};
+
+inline DebuggerStream& operator<<(DebuggerStream& stream, DebuggerStream& (*func)(DebuggerStream&)) {
+    return func(stream);
+}
+
+inline DebuggerStream& dreset(DebuggerStream& stream) {
+    stream.reset();
+    stream.flush();
+    return stream;
+}
+
+
+}
+
+#endif

--- a/src/sst/core/impl/interactive/debugStream.h
+++ b/src/sst/core/impl/interactive/debugStream.h
@@ -22,8 +22,9 @@
 
 namespace SST::IMPL::Interactive {
 
-class DebuggerStreamBuf : public std::streambuf {
-    private:
+class DebuggerStreamBuf : public std::streambuf
+{
+private:
     std::streambuf* dest_;
     unsigned        linesPerScreen_;
     unsigned        curLines_;
@@ -32,54 +33,67 @@ class DebuggerStreamBuf : public std::streambuf {
     unsigned        charsPerLine_;
     unsigned        curChars_;
 
-    protected:
+protected:
     virtual int_type overflow(int_type c) override;
-    virtual int sync() override;
+    virtual int      sync() override;
 
 
-    public:
-    DebuggerStreamBuf(std::streambuf* dest, unsigned linesPerScreen, unsigned charsPerLine) 
-        : dest_(dest), linesPerScreen_(linesPerScreen), curLines_(0),
-          paginate_(true), quit_(false), charsPerLine_(charsPerLine), curChars_(0) {}
+public:
+    DebuggerStreamBuf(std::streambuf* dest, unsigned linesPerScreen, unsigned charsPerLine) :
+        dest_(dest),
+        linesPerScreen_(linesPerScreen),
+        curLines_(0),
+        paginate_(true),
+        quit_(false),
+        charsPerLine_(charsPerLine),
+        curChars_(0)
+    {}
 
-    void reset(){
-            paginate_ = true;
-            quit_     = false;
-            curLines_ = 0;
-            curChars_ = 0;
+    void reset()
+    {
+        paginate_ = true;
+        quit_     = false;
+        curLines_ = 0;
+        curChars_ = 0;
     }
-    void setLineWidth(const unsigned w){charsPerLine_ = w;}
-
+    void setLineWidth(const unsigned w) { charsPerLine_ = w; }
 };
 
-class DebuggerStream : public std::ostream {
-    private:
+class DebuggerStream : public std::ostream
+{
+private:
     DebuggerStreamBuf buf_;
 
-    public:
-    DebuggerStream(std::ostream& dest, unsigned linesPerScreen, unsigned charsPerLine)
-        : std::ostream(&buf_), buf_(dest.rdbuf(), linesPerScreen, charsPerLine) {}
+public:
+    DebuggerStream(std::ostream& dest, unsigned linesPerScreen, unsigned charsPerLine) :
+        std::ostream(&buf_),
+        buf_(dest.rdbuf(), linesPerScreen, charsPerLine)
+    {}
 
-    void reset(){
+    void reset()
+    {
         buf_.reset();
         clear();
     }
 
-    void setLineWidth(const unsigned w){ buf_.setLineWidth(w);}
-
+    void setLineWidth(const unsigned w) { buf_.setLineWidth(w); }
 };
 
-inline DebuggerStream& operator<<(DebuggerStream& stream, DebuggerStream& (*func)(DebuggerStream&)) {
+inline DebuggerStream&
+operator<<(DebuggerStream& stream, DebuggerStream& (*func)(DebuggerStream&))
+{
     return func(stream);
 }
 
-inline DebuggerStream& dreset(DebuggerStream& stream) {
+inline DebuggerStream&
+dreset(DebuggerStream& stream)
+{
     stream.reset();
     stream.flush();
     return stream;
 }
 
 
-}
+} // namespace SST::IMPL::Interactive
 
 #endif

--- a/src/sst/core/impl/interactive/simpleDebug.cc
+++ b/src/sst/core/impl/interactive/simpleDebug.cc
@@ -79,7 +79,7 @@ std::streambuf::int_type DebuggerStreamBuf::overflow(std::streambuf::int_type c)
 
 SimpleDebugger::SimpleDebugger(Params& params) :
     InteractiveConsole(),
-    dout(std::cout, 25)
+    dout(std::cout, 25, 80)
 {
     // registerAsPrimaryComponent();
 

--- a/src/sst/core/impl/interactive/simpleDebug.cc
+++ b/src/sst/core/impl/interactive/simpleDebug.cc
@@ -31,7 +31,6 @@
 namespace SST::IMPL::Interactive {
 
 
-
 SimpleDebugger::SimpleDebugger(Params& params) :
     InteractiveConsole(),
     dout(std::cout, 50, 160)

--- a/src/sst/core/impl/interactive/simpleDebug.cc
+++ b/src/sst/core/impl/interactive/simpleDebug.cc
@@ -30,56 +30,11 @@
 
 namespace SST::IMPL::Interactive {
 
-std::streambuf::int_type DebuggerStreamBuf::overflow(std::streambuf::int_type c) {
-        if(quit_){
-            return EOF;
-        }
 
-        curChars_++;
-        if('\n' == c){
-            curLines_++;
-            curChars_=0;
-            if(paginate_ && (curLines_ % linesPerScreen_ == 0)){
-                dest_->sputc('\n');
-                dest_->pubsync();
-                std::cout << "--Type <RET> for more, q to quit, c to continue without paging--" << std::endl;
-                char cmd = std::cin.get();
-                if(('q' == cmd) || ('Q' == cmd)){
-                    quit_ = true;
-                    std::cin.ignore(1000, '\n');
-                    return EOF;
-                }else if( ('c' == cmd ) || ('C' == cmd)){
-                    paginate_ = false;
-                    std::cin.ignore(1000, '\n');
-                }else{
-                    if('\n' != cmd) std::cin.ignore(1000, '\n');
-                }
-                return c;
-            }
-        } else if( curChars_ == charsPerLine_){
-            dest_->sputc('.');
-            dest_->sputc('.');
-            return dest_->sputc('.');
-        }else if( curChars_ > charsPerLine_){
-            return c;
-        }
-        return dest_->sputc(c);
-    }
-
-    int DebuggerStreamBuf::sync() {
-        return dest_->pubsync();
-    }
-
-    void DebuggerStreamBuf::reset(){
-            paginate_ = true;
-            quit_     = false;
-            curLines_ = 0;
-            curChars_ = 0;
-    }
 
 SimpleDebugger::SimpleDebugger(Params& params) :
     InteractiveConsole(),
-    dout(std::cout, 25, 80)
+    dout(std::cout, 50, 160)
 {
     // registerAsPrimaryComponent();
 

--- a/src/sst/core/impl/interactive/simpleDebug.cc
+++ b/src/sst/core/impl/interactive/simpleDebug.cc
@@ -30,8 +30,46 @@
 
 namespace SST::IMPL::Interactive {
 
+std::streambuf::int_type DebuggerStreamBuf::overflow(std::streambuf::int_type c) {
+        if(quit_){
+            return EOF;
+        }
+
+        if('\n' == c){
+            curLines_++;
+            if(paginate_ && (curLines_ % linesPerScreen_ == 0)){
+                dest_->sputc('\n');
+                dest_->pubsync();
+                std::cout << "--Type <RET> for more, q to quit, c to continue without paging--" << std::endl;
+                char cmd = std::cin.get();
+                if(('q' == cmd) || ('Q' == cmd)){
+                    quit_ = true;
+                    return EOF;
+                }else if( ('c' == cmd ) || ('C' == cmd)){
+                    paginate_ = false;
+                    std::cin.ignore(1000, '\n');
+                }else{
+                    if('\n' != cmd) std::cin.ignore(1000, '\n');
+                }
+                return c;
+            }
+        } 
+        return dest_->sputc(c);
+    }
+
+    int DebuggerStreamBuf::sync() {
+        return dest_->pubsync();
+    }
+
+    void DebuggerStreamBuf::reset(){
+            paginate_ = true;
+            quit_ = false;
+            curLines_ = 0;
+    }
+
 SimpleDebugger::SimpleDebugger(Params& params) :
-    InteractiveConsole()
+    InteractiveConsole(),
+    dout(std::cout, 25)
 {
     // registerAsPrimaryComponent();
 
@@ -461,14 +499,30 @@ bool
 SimpleDebugger::cmd_ls(std::vector<std::string>& UNUSED(tokens))
 {
     auto& vars = obj_->getVariables();
+    unsigned lines = 0;
+    bool paginate = true;
     for ( auto& x : vars ) {
         if ( x.second->isFundamental() ) {
-            std::cout << x.first << " = " << x.second->get() << " (" << x.second->getType() << ")" << std::endl;
+            dout << x.first << " = " << x.second->get() << " (" << x.second->getType() << ")" << std::endl;
         }
         else {
-            std::cout << x.first.c_str() << "/ (" << x.second->getType() << ")\n";
+            dout << x.first.c_str() << "/ (" << x.second->getType() << ")\n";
         }
+        /*lines++;
+        if(paginate && lines > 25){
+            std::string line;
+            std::cout << "--Type <RET> for more, q to quit, c to continue without paging--" << std::endl;
+            std::getline(std::cin, line);
+            std::vector<std::string> tokens;
+            tokenize(tokens, line);
+            if(0 == tokens.size()){lines = 0; continue;}
+            else if("\n" == tokens[0]){lines = 0; continue;}
+            else if("q" == tokens[0]){ return true;}
+            else if("c" == tokens[0]){paginate = false; continue;}
+            else {lines = 0; continue;}
+        } */
     }
+    dout << dreset;
     return true;
 }
 

--- a/src/sst/core/impl/interactive/simpleDebug.h
+++ b/src/sst/core/impl/interactive/simpleDebug.h
@@ -148,7 +148,7 @@ class DebuggerStream : public std::ostream {
     DebuggerStreamBuf buf_;
 
     public:
-    DebuggerStream(std::ostream& dest, unsigned linesPerScreen = 25, unsigned charsPerLine = 80)
+    DebuggerStream(std::ostream& dest, unsigned linesPerScreen, unsigned charsPerLine)
         : std::ostream(&buf_), buf_(dest.rdbuf(), linesPerScreen, charsPerLine) {}
 
     void reset(){

--- a/src/sst/core/impl/interactive/simpleDebug.h
+++ b/src/sst/core/impl/interactive/simpleDebug.h
@@ -17,6 +17,7 @@
 #include "sst/core/interactiveConsole.h"
 #include "sst/core/serialization/objectMapDeferred.h"
 #include "sst/core/watchPoint.h"
+#include "sst/core/impl/interactive/debugStream.h"
 
 #include <cstddef>
 #include <cstdint>
@@ -117,58 +118,6 @@ private:
     bool                     searchFirst(const std::string& s, std::string& newcmd);
     bool                     searchAny(const std::string& s, std::string& newcmd);
 };
-
-class DebuggerStreamBuf : public std::streambuf {
-    private:
-    std::streambuf* dest_;
-    unsigned        linesPerScreen_;
-    unsigned        curLines_;
-    bool            paginate_;
-    bool            quit_;
-    unsigned        charsPerLine_;
-    unsigned        curChars_;
-
-    protected:
-    virtual int_type overflow(int_type c) override;
-    virtual int sync() override;
-
-
-    public:
-    DebuggerStreamBuf(std::streambuf* dest, unsigned linesPerScreen, unsigned charsPerLine) 
-        : dest_(dest), linesPerScreen_(linesPerScreen), curLines_(0),
-          paginate_(true), quit_(false), charsPerLine_(charsPerLine), curChars_(0) {}
-
-    void reset();
-    void setLineWidth(const unsigned w){charsPerLine_ = w;}
-
-};
-
-class DebuggerStream : public std::ostream {
-    private:
-    DebuggerStreamBuf buf_;
-
-    public:
-    DebuggerStream(std::ostream& dest, unsigned linesPerScreen, unsigned charsPerLine)
-        : std::ostream(&buf_), buf_(dest.rdbuf(), linesPerScreen, charsPerLine) {}
-
-    void reset(){
-        buf_.reset();
-        clear();
-    }
-
-    void setLineWidth(const unsigned w){ buf_.setLineWidth(w);}
-
-};
-
-inline DebuggerStream& operator<<(DebuggerStream& stream, DebuggerStream& (*func)(DebuggerStream&)) {
-    return func(stream);
-}
-
-inline DebuggerStream& dreset(DebuggerStream& stream) {
-    stream.reset();
-    stream.flush();
-    return stream;
-}
 
 class SimpleDebugger : public SST::InteractiveConsole
 {

--- a/src/sst/core/impl/interactive/simpleDebug.h
+++ b/src/sst/core/impl/interactive/simpleDebug.h
@@ -125,6 +125,8 @@ class DebuggerStreamBuf : public std::streambuf {
     unsigned        curLines_;
     bool            paginate_;
     bool            quit_;
+    unsigned        charsPerLine_;
+    unsigned        curChars_;
 
     protected:
     virtual int_type overflow(int_type c) override;
@@ -132,11 +134,12 @@ class DebuggerStreamBuf : public std::streambuf {
 
 
     public:
-    DebuggerStreamBuf(std::streambuf* dest, int linesPerScreen = 25) 
+    DebuggerStreamBuf(std::streambuf* dest, unsigned linesPerScreen, unsigned charsPerLine) 
         : dest_(dest), linesPerScreen_(linesPerScreen), curLines_(0),
-          paginate_(true), quit_(false) {}
+          paginate_(true), quit_(false), charsPerLine_(charsPerLine), curChars_(0) {}
 
     void reset();
+    void setLineWidth(const unsigned w){charsPerLine_ = w;}
 
 };
 
@@ -145,13 +148,15 @@ class DebuggerStream : public std::ostream {
     DebuggerStreamBuf buf_;
 
     public:
-    DebuggerStream(std::ostream& dest, int linesPerScreen = 25)
-        : std::ostream(&buf_), buf_(dest.rdbuf(), linesPerScreen) {}
+    DebuggerStream(std::ostream& dest, unsigned linesPerScreen = 25, unsigned charsPerLine = 80)
+        : std::ostream(&buf_), buf_(dest.rdbuf(), linesPerScreen, charsPerLine) {}
 
     void reset(){
         buf_.reset();
         clear();
     }
+
+    void setLineWidth(const unsigned w){ buf_.setLineWidth(w);}
 
 };
 

--- a/src/sst/core/impl/interactive/simpleDebug.h
+++ b/src/sst/core/impl/interactive/simpleDebug.h
@@ -14,10 +14,10 @@
 
 #include "sst/core/eli/elementinfo.h"
 #include "sst/core/impl/interactive/cmdLineEditor.h"
+#include "sst/core/impl/interactive/debugStream.h"
 #include "sst/core/interactiveConsole.h"
 #include "sst/core/serialization/objectMapDeferred.h"
 #include "sst/core/watchPoint.h"
-#include "sst/core/impl/interactive/debugStream.h"
 
 #include <cstddef>
 #include <cstdint>


### PR DESCRIPTION
This addresses Issue #42 (and a little bit of #44 ) by adding functionality for the debugger to pause long running (multiple screens, or long lines) outputs.  Currently if the output of the `ls` command goes beyond 50 lines the user is greeted with the message:

`--Type <RET> for more, q to quit, c to continue without paging--`

In addition, any lines longer than 160 characters are truncated with `...`

This is accomplished by adding a new stream class `DebugStream` - declared as a new member named `dout` in `SimpleDebugger`  It is used as a drop in replacement for `std::cout` and has an overloaded `<<` operator. The key difference is you must call `dout << dreset` after each use to reset the stream state.  No additional buffers are needed. `DebugStream` may implement other stream modifiers that are passed in as function pointers.

Along with this PR is a slight change to the CaptCrunch_Interactive test - an independent PR for that is also posted in the sst-ext-tests repo.
