### PR TITLE
Update dump trace functions and ensure console returns to last thread

### DIFF
--- a/src/sst/core/impl/interactive/simpleDebug.cc
+++ b/src/sst/core/impl/interactive/simpleDebug.cc
@@ -401,8 +401,6 @@ SimpleDebugger::consoleExecute(const std::string& msg)
 
     // SKK TODO For now start with thread, rank of 0
     // Eventually change to triggered or last thread
-    current_thread = 0;
-    current_rank = 0;
     std::cout << "---- Rank" << current_rank << ":Thread" << current_thread << ": Entering interactive mode at time " 
             << getCurrentSimCycle() << std::endl;
     std::cout << msg << std::endl;

--- a/src/sst/core/serialization/objectMap.h
+++ b/src/sst/core/serialization/objectMap.h
@@ -1189,7 +1189,7 @@ public:
                 ObjectBuffer* varBuffer_ = objBuffers_[obj];
                 std::cout << SST::Core::to_string(varBuffer_->getName()) << "=" << varBuffer_->get(i) << " ";
             }
-            std::cout << std::endl;
+            std::cout << "\n";
 
             if ( i == end ) {
                 break;
@@ -1199,17 +1199,19 @@ public:
 
     void dumpTriggerRecord()
     {
+      std::stringstream ss;
         if ( numRecs_ == 0 ) {
             std::cout << "No trace samples in current buffer" << std::endl;
             return;
         }
         if ( state_ != CLEAR ) {
-            std::cout << "LastTriggerRecord:@cycle" << triggerCycle << ": SamplesLost=" << samplesLost_ << ": ";
+            ss << "LastTriggerRecord:@cycle" << triggerCycle << ": SamplesLost=" << samplesLost_ << ": ";
             for ( size_t obj = 0; obj < numObjects; obj++ ) {
                 ObjectBuffer* varBuffer_ = objBuffers_[obj];
-                std::cout << SST::Core::to_string(varBuffer_->getName()) << "=" << varBuffer_->getTriggerVal() << " ";
+                ss << SST::Core::to_string(varBuffer_->getName()) << "=" << varBuffer_->getTriggerVal() << " ";
             }
-            std::cout << std::endl;
+            ss << "\n";
+            std::cout << ss.str();
         }
     }
 

--- a/src/sst/core/watchPoint.cc
+++ b/src/sst/core/watchPoint.cc
@@ -204,7 +204,7 @@ void
 WatchPoint::printTrace()
 {
     if ( tb_ != nullptr ) {
-        std::cout << "TriggerCount=" << triggerCount << std::endl;
+        std::cout << "TriggerCount=" << triggerCount << "\n";
         tb_->dumpTriggerRecord();
         tb_->dumpTraceBufferT();
     }


### PR DESCRIPTION
* Updates the dump trace buffer and trigger functions to use a stringstream in order to ensure they aren't interleaved with other prints
* Ensures the  console returns to the last thread, rather than rank0/thread0

Requires updated sst-ext-tests: https://github.com/tactcomplabs/sst-ext-tests/pull/121
