### PR TITLE
Fix realtime shutdown issue

### DIFF
--- a/src/sst/core/interactiveConsole.cc
+++ b/src/sst/core/interactiveConsole.cc
@@ -117,7 +117,7 @@ InteractiveConsole::simulationShutdown()
 {
     // Simulation_impl::getSimulation()->endSimulation();  // Only works for single thread
     std::cout << "Simulation shutdown\n";
-    Simulation_impl::getSimulation()->signalShutdown(false);
+    Simulation_impl::getSimulation()->consoleShutdown(false);
 }
 
 

--- a/src/sst/core/simulation.cc
+++ b/src/sst/core/simulation.cc
@@ -1220,6 +1220,19 @@ Simulation_impl::signalShutdown(bool abnormal)
         shutdown_mode_ = SHUTDOWN_CLEAN;
     }
 
+    endSim = true;
+}
+
+void
+Simulation_impl::consoleShutdown(bool abnormal)
+{
+    if ( abnormal ) {
+        shutdown_mode_ = SHUTDOWN_SIGNAL;
+    }
+    else {
+        shutdown_mode_ = SHUTDOWN_CLEAN;
+    }
+
     if ( num_ranks.rank == 1 && num_ranks.thread == 1 ) {
         // Set endsim right away if serial
         endSim = true;

--- a/src/sst/core/simulation_impl.h
+++ b/src/sst/core/simulation_impl.h
@@ -484,6 +484,12 @@ public:
      */
     void signalShutdown(bool abnormal);
 
+    /** Console Shutdown
+     * Called when a shutdown command or watchpoint shutdown action trigger needs to terminate SST
+     */
+    void consoleShutdown(bool abnormal);
+
+
     /** Set EndSim
      * Called by SyncMgr when interactive console ready to shutdown
      */

--- a/src/sst/core/watchPoint.cc
+++ b/src/sst/core/watchPoint.cc
@@ -350,7 +350,7 @@ WatchPoint::heartbeat()
 void
 WatchPoint::simulationShutdown()
 {
-    Simulation_impl::getSimulation()->signalShutdown(false);
+    Simulation_impl::getSimulation()->consoleShutdown(false);
     std::cout << "wp simulation shutdown\n";
 }
 


### PR DESCRIPTION
Added a separate shutdown path for the watchpoints/console shutdown command so that it doesn't interfere with the functionality of the realtime signal shutdown. The realtime signal is only captured by thread 0 and handled in the sync. The watchpoints can trigger in any thread during run, so they have to mark a flag and wait for the sync to handle to the shutdown.  This passes the sst-test-core realtime tests for -t 2, -t 4, -r 2, and -r2-t2 as well as all the DebugConsole tests. 