### PR TITLE
Update EmptyRankSync warning to only trigger if interactive console or checkpoint enabled

### DIFF
--- a/src/sst/core/config.cc
+++ b/src/sst/core/config.cc
@@ -664,6 +664,15 @@ Config::canInitiateCheckpoint()
     return false;
 }
 
+bool
+Config::canInitiateInteractive()
+{
+    if ( interactive_start_time_.value != "" ) return true;
+    if ( sigusr1() == "sst.rt.interactive" ) return true;
+    if ( sigusr2() == "sst.rt.interactive" ) return true;
+    return false;
+}
+
 // Set the prefix for checkpoint files
 int
 Config::parse_checkpoint_name_format(std::string& var, std::string arg)

--- a/src/sst/core/config.h
+++ b/src/sst/core/config.h
@@ -620,6 +620,9 @@ public:
     /** Get whether or not any of the checkpoint options were turned on */
     bool canInitiateCheckpoint();
 
+    /** Get whether or not any of the interactive options were turned on */
+    bool canInitiateInteractive();
+
     /** Print to stdout the current configuration */
     void print();
 

--- a/src/sst/core/sync/syncManager.cc
+++ b/src/sst/core/sync/syncManager.cc
@@ -400,9 +400,12 @@ SyncManager::setupSyncObjects()
         }
         else {
             rankSync_ = new EmptyRankSync(num_ranks_);
-            if ( num_ranks_.rank > 1 )
-                sim_->getSimulationOutput().output(
-                    "WARNING: EmptyRankSync: Checkpoint and interactive debug disabled\n");
+            if ( num_ranks_.rank > 1 &&
+                 (real_time_->canInitiateCheckpoint() || sim_->config.canInitiateInteractive()) ) {
+                if ( rank_.rank == 0 )
+                    sim_->getSimulationOutput().output(
+                        "WARNING: EmptyRankSync: Checkpoint and interactive debug disabled\n");
+            }
         }
     }
 


### PR DESCRIPTION
Checks for interactive console or checkpoint enabled before printing warning.


