### PR TITLE
Separate realtime check for interactive console from configuration check

### DIFF
--- a/src/sst/core/config.cc
+++ b/src/sst/core/config.cc
@@ -668,8 +668,6 @@ bool
 Config::canInitiateInteractive()
 {
     if ( interactive_start_time_.value != "" ) return true;
-    if ( sigusr1() == "sst.rt.interactive" ) return true;
-    if ( sigusr2() == "sst.rt.interactive" ) return true;
     return false;
 }
 

--- a/src/sst/core/realtime.cc
+++ b/src/sst/core/realtime.cc
@@ -577,6 +577,7 @@ RealTimeManager::registerSignal(RealTimeAction* action, int signum)
 {
     signal_actions_.insert(std::make_pair(signum, action));
     if ( action->canInitiateCheckpoint() ) can_checkpoint_ = true;
+    if ( action->canInitiateInteractive() ) can_initiate_interactive_ = true;
 }
 
 void
@@ -589,6 +590,7 @@ RealTimeManager::registerInterval(uint32_t interval, RealTimeAction* action)
 
     static_cast<AlrmSignalAction*>(signal_actions_[SIGALRM])->addIntervalAction(interval, action);
     if ( action->canInitiateCheckpoint() ) can_checkpoint_ = true;
+    if ( action->canInitiateInteractive() ) can_initiate_interactive_ = true;
 }
 
 void

--- a/src/sst/core/realtime.h
+++ b/src/sst/core/realtime.h
@@ -130,6 +130,7 @@ public:
     // Separate --checkpoint-enable flag is currently used to control checkpointing for interactive console
     // If we set canInitiateCheckpoint to true here, it will ALWAYS set up checkpointing and the flag is unnecessary
     bool canInitiateCheckpoint() override { return false; }
+    bool canInitiateInteractive() override { return true; }
 };
 
 /* Wrapper for RealTimeActions that occur on a time interval */
@@ -209,12 +210,20 @@ public:
      */
     bool canInitiateCheckpoint() { return can_checkpoint_; }
 
+    /**
+       Check whether or not any of the Actions registered with the
+       manager can initiate the interactive console.
+     */
+    bool canInitiateInteractive() { return can_initiate_interactive_; }
+
     void serialize_order(SST::Core::Serialization::serializer& ser) override;
     ImplementSerializable(SST::RealTimeManager)
 
 private:
-    bool serial_exec_;            // Whether execution is serial or parallel
-    bool can_checkpoint_ = false; // Set to true if any Actions can trigger checkpoint
+    bool serial_exec_;                      // Whether execution is serial or parallel
+    bool can_checkpoint_           = false; // Set to true if any Actions can trigger checkpoint
+    bool can_initiate_interactive_ = false; // Set to true if any Actions can trigger interactive console
+
 
     /* The set of signal handlers for all signals */
     std::map<int, RealTimeAction*> signal_actions_;

--- a/src/sst/core/realtimeAction.h
+++ b/src/sst/core/realtimeAction.h
@@ -54,6 +54,11 @@ public:
      */
     virtual bool canInitiateCheckpoint() { return false; }
 
+    /**
+       Lets the core know if this action may trigger an interactive console.
+     */
+    virtual bool canInitiateInteractive() { return false; }
+
     /* Reports whether the action is valid for use with sigalrm */
     virtual bool isValidSigalrmAction() { return true; }
 

--- a/src/sst/core/sync/syncManager.cc
+++ b/src/sst/core/sync/syncManager.cc
@@ -401,7 +401,8 @@ SyncManager::setupSyncObjects()
         else {
             rankSync_ = new EmptyRankSync(num_ranks_);
             if ( num_ranks_.rank > 1 &&
-                 (real_time_->canInitiateCheckpoint() || sim_->config.canInitiateInteractive()) ) {
+                 (real_time_->canInitiateCheckpoint() || sim_->config.canInitiateCheckpoint() ||
+                     real_time_->canInitiateInteractive() || sim_->config.canInitiateInteractive()) ) {
                 if ( rank_.rank == 0 )
                     sim_->getSimulationOutput().output(
                         "WARNING: EmptyRankSync: Checkpoint and interactive debug disabled\n");


### PR DESCRIPTION
Creates separate canInitiateInteractive functions for realtime and configuration. Updates the empty rank sync warning to check both. 
