### PR TITLE
changed use of ctrl+d to shutdown the simulator.

### DIFF
--- a/src/sst/core/impl/interactive/cmdLineEditor.cc
+++ b/src/sst/core/impl/interactive/cmdLineEditor.cc
@@ -363,7 +363,7 @@ CmdLineEditor::getline(const std::vector<std::string>& cmdHistory, std::string& 
         else if ( c == ctrl_d ) {
             int position = curpos - prompt.size() - 1;
             if ( position == 0 && history[index].size() == 0 ) {
-                // if the line is empty then quit (tactcomplabs/sst-core #32)
+                // if the line is empty then shutdown (tactcomplabs/sst-core #32)
                 end_of_file = true;
                 break;
             }
@@ -425,7 +425,7 @@ CmdLineEditor::getline(const std::vector<std::string>& cmdHistory, std::string& 
 
     // set the new line info
     if ( end_of_file )
-        newcmd = "quit";
+        newcmd = "shutdown";
     else
         newcmd = history[index];
 

--- a/src/sst/core/impl/interactive/debugConsole.cc
+++ b/src/sst/core/impl/interactive/debugConsole.cc
@@ -391,7 +391,7 @@ DebugConsole::DebugConsole(Params& params) :
                      "\ttab: auto-completion\n"
                      "\tctrl-a: move cursor to beginning of line\n"
                      "\tctrl-b: move cursor to the left\n"
-                     "\tctrl-d: delete character at cursor or quit debugger\n"
+                     "\tctrl-d: delete character at cursor or shutdown\n"
                      "\tctrl-e: move cursor to end of line\n"
                      "\tctrl-f: move cursor to the right\n" 
                      "\tNote: this functionality is not available when using mpi"},
@@ -609,6 +609,12 @@ DebugConsole::cd_name_stack()
 bool
 DebugConsole::dispatch_cmd(std::string& cmd)
 {
+    // ctrl+d 
+    if (std::cin.eof()) {
+        std::cout << "<ctrl+d>" << std::endl;
+        cmd="shutdown";
+    }
+
     // empty command
     if ( cmd.size() == 0 ) return true;
 


### PR DESCRIPTION
This fixes a problem  7 in issue #64 where ctrl+d causes a runaway prompt.

Shutting down instead of quitting the console is still consistent with EOF usage.  The problem with not shutting down is that the std::cin stream cannot be restarted under MPI for some platforms ( AFIK ). This way at least the simulation will shut down cleanly vs having to ctrl-C to kill the process.

