### PR TITLE
ObjTree print update and cast fix (issue #64)

### DIFF
--- a/src/sst/core/impl/interactive/debugConsole.cc
+++ b/src/sst/core/impl/interactive/debugConsole.cc
@@ -1899,10 +1899,6 @@ DebugConsole::cmd_print_remote(std::vector<std::string>& tokens)
 
     auto* target = curObj_->findByName(tokens[var_index]);
     if ( target ) {
-        // auto tmp = SST::Core::Serialization::NumericHandle::from(target);
-        // bool gt = false;
-        // if(tmp < 100) gt = true;
-        // if(gt) printf("----- True ---- ");
         if ( !indices.empty() ) {
             SST::Core::Serialization::ContainerObj* tmp = dynamic_cast<SST::Core::Serialization::ContainerObj*>(target);
             if ( tmp ) {
@@ -1916,6 +1912,15 @@ DebugConsole::cmd_print_remote(std::vector<std::string>& tokens)
         else {
             target->Dump(print_verbose + 1, base, result);
             if ( recurse > 0 ) {
+                if(target->getChildren().empty()){
+                    // Object we are trying to recursively print has (potentially) not yet been serialized
+                    // If it's a ComponentObj that hasn't been serialized yet, serialize it
+                    if ( auto* comp = dynamic_cast<Core::Serialization::ComponentObj*>(target) ) {
+                        if ( comp->getChildren().empty() ) {
+                            Core::Serialization::ObjectMapToTree::serializeComponent(comp, true);
+                        }
+                    }
+                }
                 target->applyRecursive([print_verbose, base](SST::Core::Serialization::ObjTreeCont* child) {
                     child->Dump(print_verbose + 1, base, result);
                 });

--- a/src/sst/core/serialization/ObjTree.h
+++ b/src/sst/core/serialization/ObjTree.h
@@ -80,8 +80,12 @@ namespace SST::Core::Serialization {
             std::cout << "Processing component: " << val_->getName() << std::endl;
         }
         void Dump([[maybe_unused]] const int verbosity, [[maybe_unused]] std::ios_base::fmtflags base = std::ios_base::dec, std::ostream& os = std::cout) override{
-            os << val_->getName() << "/" << std::endl;
+         if(verbosity < 3)
+                os << val_->getName() << "/" << std::endl;
+            else
+                os << val_->getName() << "/ (" << compInfo_->getType() << ")" << std::endl;
         }
+
 
         ComponentObj* find(const std::string name){
             ComponentObj* result = nullptr;

--- a/src/sst/core/serialization/ObjTreeLeaves.h
+++ b/src/sst/core/serialization/ObjTreeLeaves.h
@@ -440,7 +440,7 @@ namespace SST::Core::Serialization {
             if (useAccessor_ && getter_) {
                 const long double live = getter_();
                 return std::visit([live](const auto& v) -> bool {
-                    return static_cast<int64_t>(v) != static_cast<int64_t>(live);
+                    return static_cast<long double>(v) != live;
                 }, val_);
             } else if (addr_) {
                 return std::visit([this](const auto& v) -> bool {


### PR DESCRIPTION
Addresses two items in #64 

1) print -r N component does not print top level component - fixed. We now serialize on a recursive print request if the underlying component is not yet serialized. This allows for a recursive print

2) Compiler warnings: in the `hasChanged()` function of `FloatObj` there was a incorrect cast to `int64` rather than `long double` 

3) Misc dead code removal
