### PR TITLE
address sanitizer fix

### DIFF
--- a/src/sst/core/impl/interactive/debugConsole.cc
+++ b/src/sst/core/impl/interactive/debugConsole.cc
@@ -5156,7 +5156,11 @@ DebugConsole::executeRankParallel(const std::string& UNUSED_WO_MPI(msg))
 
         // Set done in local rank threads
         tokens.clear();
-        tokens[0] = "done";
+        if (tokens.size()==0) {
+            tokens.push_back("done");
+        } else {
+            tokens[0] = "done";
+        }
         handleCommand();
 
         // Send done to remote ranks


### PR DESCRIPTION
Fixes address sanitizer error about `sst-ext-tests/tests/debug-console-mpi/cmd-r4-t2-rank3-actions.sh`
Error is: `WRITE of size 4 at 0x61700006d300 thread T0`
At this line of code:
```
   // Enter console to handle commands
        consoleExecute(msg);

        // Set done in local rank threads
        tokens.clear();
        tokens[0] = "done";  <--- HERE
        handleCommand();

        // Send done to remote ranks
        sendDone();
```