### PR TITLE
Fix debugger output stream not atomic

### DIFF
--- a/src/sst/core/impl/interactive/ObjTreeHelpers.h
+++ b/src/sst/core/impl/interactive/ObjTreeHelpers.h
@@ -321,7 +321,7 @@ public:
             return;
         }
         if ( state_ != CLEAR ) {
-            std::stringstream ss;  // Need to buffer in a stream so it doesn't get split in parallel execution
+            std::stringstream  ss; // Need to buffer in a stream so it doesn't get split in parallel execution
             std::ostringstream tmpBuf;
             std::string        objNames;
             unsigned           idxToPrint = 0;
@@ -348,8 +348,7 @@ public:
                 tmpBuf.clear();
             }
             ss << objNames << std::endl;
-            os << ss.str();  // Print everything at once to avoid splitting
-            
+            os << ss.str(); // Print everything at once to avoid splitting
         }
     }
 

--- a/src/sst/core/impl/interactive/ObjTreeHelpers.h
+++ b/src/sst/core/impl/interactive/ObjTreeHelpers.h
@@ -321,11 +321,12 @@ public:
             return;
         }
         if ( state_ != CLEAR ) {
+            std::stringstream ss;  // Need to buffer in a stream so it doesn't get split in parallel execution
             std::ostringstream tmpBuf;
             std::string        objNames;
             unsigned           idxToPrint = 0;
             // print trigger value for the one variable (variables?) that actually triggered
-            os << "LastTriggerRecord:@cycle" << triggerCycle << ": SamplesLost=" << samplesLost_ << ": ";
+            ss << "LastTriggerRecord:@cycle" << triggerCycle << ": SamplesLost=" << samplesLost_ << ": ";
             for ( size_t obj = 0; obj < objBuffers_.size(); obj++ ) {
                 unsigned triggerIdx = std::get<unsigned>(objBuffers_[obj]);
                 auto*    record     = &std::get<std::vector<std::unique_ptr<ObjTreeCont>>>(objBuffers_[obj]);
@@ -346,7 +347,9 @@ public:
                 tmpBuf.str("");
                 tmpBuf.clear();
             }
-            os << objNames << std::endl;
+            ss << objNames << std::endl;
+            os << ss.str();  // Print everything at once to avoid splitting
+            
         }
     }
 

--- a/src/sst/core/impl/interactive/debugConsole.cc
+++ b/src/sst/core/impl/interactive/debugConsole.cc
@@ -1958,7 +1958,7 @@ DebugConsole::cmd_print_remote(std::vector<std::string>& tokens)
         else {
             target->Dump(print_verbose + 1, base, result);
             if ( recurse > 0 ) {
-                if(target->getChildren().empty()){
+                if ( target->getChildren().empty() ) {
                     // Object we are trying to recursively print has (potentially) not yet been serialized
                     // If it's a ComponentObj that hasn't been serialized yet, serialize it
                     if ( auto* comp = dynamic_cast<Core::Serialization::ComponentObj*>(target) ) {
@@ -5156,9 +5156,10 @@ DebugConsole::executeRankParallel(const std::string& UNUSED_WO_MPI(msg))
 
         // Set done in local rank threads
         tokens.clear();
-        if (tokens.size()==0) {
+        if ( tokens.size() == 0 ) {
             tokens.push_back("done");
-        } else {
+        }
+        else {
             tokens[0] = "done";
         }
         handleCommand();

--- a/src/sst/core/serialization/ObjTree.h
+++ b/src/sst/core/serialization/ObjTree.h
@@ -89,9 +89,10 @@ public:
     void Dump([[maybe_unused]] const int verbosity, [[maybe_unused]] std::ios_base::fmtflags base = std::ios_base::dec,
         std::ostream& os = std::cout) override
     {
-        if(verbosity < 3){
+        if ( verbosity < 3 ) {
             os << val_->getName() << "/" << std::endl;
-        }else{
+        }
+        else {
             os << val_->getName() << "/ (" << compInfo_->getType() << ")" << std::endl;
         }
     }

--- a/src/sst/core/serialization/ObjTreeLeaves.h
+++ b/src/sst/core/serialization/ObjTreeLeaves.h
@@ -521,7 +521,8 @@ public:
         if ( useAccessor_ && getter_ ) {
             const long double live = getter_();
             return std::visit(
-                [live](const auto& v) -> bool { return static_cast<long double>(v) != static_cast<long double>(live); }, val_);
+                [live](const auto& v) -> bool { return static_cast<long double>(v) != static_cast<long double>(live); },
+                val_);
         }
         else if ( addr_ ) {
             return std::visit(


### PR DESCRIPTION
Resolves the issue with the trigger dump information being split during parallel execution. It writes all the information to a string stream, then dumps it to the ostream all at once. 

