### PR TITLE
Filter types in test_tracebuf

### DIFF
--- a/src/sst/core/impl/interactive/debugConsole.cc
+++ b/src/sst/core/impl/interactive/debugConsole.cc
@@ -1958,7 +1958,7 @@ DebugConsole::cmd_print_remote(std::vector<std::string>& tokens)
         else {
             target->Dump(print_verbose + 1, base, result);
             if ( recurse > 0 ) {
-                if(target->getChildren().empty()){
+                if ( target->getChildren().empty() ) {
                     // Object we are trying to recursively print has (potentially) not yet been serialized
                     // If it's a ComponentObj that hasn't been serialized yet, serialize it
                     if ( auto* comp = dynamic_cast<Core::Serialization::ComponentObj*>(target) ) {

--- a/src/sst/core/serialization/ObjTree.h
+++ b/src/sst/core/serialization/ObjTree.h
@@ -89,9 +89,10 @@ public:
     void Dump([[maybe_unused]] const int verbosity, [[maybe_unused]] std::ios_base::fmtflags base = std::ios_base::dec,
         std::ostream& os = std::cout) override
     {
-        if(verbosity < 3){
+        if ( verbosity < 3 ) {
             os << val_->getName() << "/" << std::endl;
-        }else{
+        }
+        else {
             os << val_->getName() << "/ (" << compInfo_->getType() << ")" << std::endl;
         }
     }

--- a/src/sst/core/serialization/ObjTreeLeaves.h
+++ b/src/sst/core/serialization/ObjTreeLeaves.h
@@ -521,7 +521,8 @@ public:
         if ( useAccessor_ && getter_ ) {
             const long double live = getter_();
             return std::visit(
-                [live](const auto& v) -> bool { return static_cast<long double>(v) != static_cast<long double>(live); }, val_);
+                [live](const auto& v) -> bool { return static_cast<long double>(v) != static_cast<long double>(live); },
+                val_);
         }
         else if ( addr_ ) {
             return std::visit(

--- a/tests/Makefile.inc
+++ b/tests/Makefile.inc
@@ -15,6 +15,7 @@ EXTRA_DIST += \
     tests/cmd_DebugConsole_serial1.cmd \
     tests/cmd_DebugConsole_thread0.cmd \
     tests/cmd_DebugConsole_thread1.cmd \
+    tests/cmd_DebugConsole_tracebuf.cmd \
     tests/testsuite_default_Checkpoint.py \
     tests/testsuite_default_Component.py \
     tests/testsuite_default_ComponentExtension.py \
@@ -94,6 +95,7 @@ EXTRA_DIST += \
     tests/refFiles/test_DebugConsole_serial1.out \
     tests/refFiles/test_DebugConsole_thread0.out \
     tests/refFiles/test_DebugConsole_thread1.out \
+    tests/refFiles/test_DebugConsole_tracebuf.out \
     tests/refFiles/test_PerfComponent.out \
     tests/refFiles/test_DistribComponent_discrete.out \
     tests/refFiles/test_DistribComponent_expon.out \

--- a/tests/testsuite_default_DebugConsole.py
+++ b/tests/testsuite_default_DebugConsole.py
@@ -129,10 +129,14 @@ class testcase_DebugConsole(SSTTestCase):
         # Filter out printstatus queue order due to differences across architectures
         filter2 = LineFilter();
         filter2 = RemoveRegexFromLineFilter(r"queue order:.*")
+        # Filter out printstatus queue order due to differences across architectures
+        filter3 = LineFilter();
+        filter3 = RemoveRegexFromLineFilter(r"std::vector<SST::Link.*")
+
 
         # Perform the test comparison with refFile
         #cmp_result = testing_compare_sorted_diff(testtype, outfile, reffile)
-        cmp_result = testing_compare_filtered_diff(testtype, outfile, reffile, sort=True, filters=[filter1, filter2])
+        cmp_result = testing_compare_filtered_diff(testtype, outfile, reffile, sort=True, filters=[filter1, filter2, filter3])
         if not cmp_result:
             diffdata = testing_get_diff_data(testtype)
             log_failure(diffdata)

--- a/tests/testsuite_default_DebugConsole.py
+++ b/tests/testsuite_default_DebugConsole.py
@@ -129,7 +129,7 @@ class testcase_DebugConsole(SSTTestCase):
         # Filter out printstatus queue order due to differences across architectures
         filter2 = LineFilter();
         filter2 = RemoveRegexFromLineFilter(r"queue order:.*")
-        # Filter out printstatus queue order due to differences across architectures
+        # Filter out variable types due to differences across architectures
         filter3 = LineFilter();
         filter3 = RemoveRegexFromLineFilter(r"std::.*")
 

--- a/tests/testsuite_default_DebugConsole.py
+++ b/tests/testsuite_default_DebugConsole.py
@@ -131,7 +131,7 @@ class testcase_DebugConsole(SSTTestCase):
         filter2 = RemoveRegexFromLineFilter(r"queue order:.*")
         # Filter out printstatus queue order due to differences across architectures
         filter3 = LineFilter();
-        filter3 = RemoveRegexFromLineFilter(r"std::vector<SST::Link.*")
+        filter3 = RemoveRegexFromLineFilter(r"std::.*")
 
 
         # Perform the test comparison with refFile


### PR DESCRIPTION
Variable types are output differently on different systems. This filters out the types in test_tracebuf to avoid failures. 