### PR TITLE
Add check for invalid types in set var action during trace creation

### DIFF
--- a/src/sst/core/impl/interactive/debugConsole.cc
+++ b/src/sst/core/impl/interactive/debugConsole.cc
@@ -3241,9 +3241,50 @@ parseComparison(std::vector<std::string>& tokens, size_t& index, Core::Serializa
     return op;
 }
 
+// Add function to check for type mismatch in 'set <var> <val>' action
+bool
+DebugConsole::checkValue(Core::Serialization::ObjTreeCont::NodeKind expectedType, const std::string& valToCheck)
+{
+    switch ( expectedType ) {
+    case Core::Serialization::ObjTreeCont::NodeKind::Integer:
+        try {
+            size_t pos = 0;
+            [[maybe_unused]]
+            int64_t v = std::stoll(valToCheck, &pos);
+            return (valToCheck.size() == pos);
+        }
+        catch ( ... ) {
+            return false;
+        }
+        break;
+    case Core::Serialization::ObjTreeCont::NodeKind::Float:
+        try {
+            size_t pos = 0;
+            [[maybe_unused]]
+            double v = std::stold(valToCheck, &pos);
+            return (valToCheck.size() == pos);
+        }
+        catch ( ... ) {
+            return false;
+        }
+        break;
+    case Core::Serialization::ObjTreeCont::NodeKind::String:
+        return true;
+        break;
+    case Core::Serialization::ObjTreeCont::NodeKind::Bool:
+        if ( valToCheck == "true" || valToCheck == "false" || valToCheck == "1" || valToCheck == "0" ) {
+            return true;
+        }
+        return false;
+        break;
+    default:
+        return false;
+    }
+}
+
 // helper function to parse watchpoint action string
 WatchPoint::WPAction*
-parseAction(std::vector<std::string>& tokens, size_t& index, Core::Serialization::ObjTreeCont* obj)
+DebugConsole::parseAction(std::vector<std::string>& tokens, size_t& index, Core::Serialization::ObjTreeCont* obj)
 {
     const std::string& action = tokens[index++];
 
@@ -3279,6 +3320,12 @@ parseAction(std::vector<std::string>& tokens, size_t& index, Core::Serialization
         Core::Serialization::ObjTreeCont* map = obj->findByName(tvar);
         if ( nullptr == map ) {
             std::cout << "Unknown variable: " << tvar << std::endl;
+            return nullptr;
+        }
+
+        // Check for valid value
+        if ( !checkValue(map->getKind(), tval) ) {
+            std::cout << "Invalid type for value: " << tval << std::endl;
             return nullptr;
         }
 

--- a/src/sst/core/impl/interactive/debugConsole.h
+++ b/src/sst/core/impl/interactive/debugConsole.h
@@ -284,8 +284,12 @@ private:
     bool                containsArg(const std::string tok, const char arg);
     size_t              containsArg(const std::vector<std::string> tokens, const std::string& arg);
     std::vector<size_t> parseBracketIndices(std::string& token);
+    bool checkValue(Core::Serialization::ObjTreeCont::NodeKind expectedType, const std::string& valToCheck);
+    WatchPoint::WPAction* parseAction(
+        std::vector<std::string>& tokens, size_t& index, Core::Serialization::ObjTreeCont* obj);
+
     // Pagination support
-    DebuggerStream      dout;
+    DebuggerStream dout;
 
     // Support for serial, threaded, rank serial, rank parallel execution
     static uint32_t                 current_thread;

--- a/src/sst/core/watchPoint.cc
+++ b/src/sst/core/watchPoint.cc
@@ -70,10 +70,13 @@ void
 WatchPoint::SetVarWPAction::invokeAction(WatchPoint* wp)
 {
     try {
-        obj_->setFromString(valStr_);
+        if ( !obj_->setFromString(valStr_) ) {
+            printf("Invalid set var action: %s\n", valStr_.c_str());
+            return;
+        }
     }
     catch ( const std::exception& e ) {
-        printf("Invalid set var: %s\n", valStr_.c_str());
+        printf("Invalid set var action: %s\n", valStr_.c_str());
         return;
     }
 


### PR DESCRIPTION
Issue: When creating a trace with a set <var> <val> action there was no error checking so any errors would not be caught until the trace action was triggered during execution. 

This adds checking at trace creation to print an error and abort trace creation if there is a type mismatch for the set action. 
